### PR TITLE
Adding key mapping logic for `Korean/English` transition key

### DIFF
--- a/vncviewer/KeyMap.h
+++ b/vncviewer/KeyMap.h
@@ -157,6 +157,9 @@ static const vncKeyMapping_t keyMap[] = {
     {XK_KP_7                , VK_NUMPAD7        , 0},
     {XK_KP_8                , VK_NUMPAD8        , 0},
     {XK_KP_9                , VK_NUMPAD9        , 0},
+
+    // Add hangul keymapping
+    {XK_Hangul              , VK_HANGEUL        , 0},
 };
 
 // Define the deadKeyMap structure

--- a/winvnc/winvnc/vnckeymap.cpp
+++ b/winvnc/winvnc/vnckeymap.cpp
@@ -756,17 +756,15 @@ public:
 	  else if (down && (vkCode == VK_HANGEUL))
 	  {
 		  HWND hWnd = GetForegroundWindow();
+		  
 		  HWND hIME_Main = ImmGetDefaultIMEWnd(hWnd);
 		  LRESULT MainStatus = ::SendMessage(hIME_Main, WM_IME_CONTROL, 5, 0);
-		  char ch[255];
-		  GetWindowText(hWnd, ch, 254);
+		  
 		  HWND hChildWnd = GetWindow(hWnd, GW_CHILD);
 		  long childCount = 0L;
+
 		  while (IsWindow(hChildWnd))
 		  {
-			  char chName[255];
-			  GetWindowText(hChildWnd, chName, 254);
-
 			  HWND hIME = ImmGetDefaultIMEWnd(hChildWnd);
 			  if (MainStatus == 1)
 			  {


### PR DESCRIPTION
I heard that there are many inconveniences for `Korean` users because the `Korean/English` transition key is not mapped from the existing source.

So, I analyzed the source to solve the issue and found that the key mapping for `Hangul` was missing. Also added logic to send key events so that child controls inside a specific window can be applied.

@RudiDeVos @bald @bernhardu 
Please review and merge for Korean users 😉 

### For Korean
한국에서 uVNC를 사용하는 사람이 많이 있고 꾸준히 한/영키 전환을 하게 해달라는 요청이 있는걸 보았습니다.
혹시나 해당 PR이 반영되지 않는다고 하면 제 개인 Repository에 포크된 소스가 있으니 변경된 부분만 별도로 추가하셔서 빌드하셔서 사용하시길 바랍니다. 