### PR TITLE
Logging improvements

### DIFF
--- a/addon/ms-logon/authSSP/EventLogging.cpp
+++ b/addon/ms-logon/authSSP/EventLogging.cpp
@@ -112,7 +112,13 @@ void LOG(long EventID, const TCHAR *format, ...) {
 	va_start(ap, format);
 	_vstprintf_s(szText, format, ap);
 	va_end(ap);
-	ps[0] = szText;
+	// Prepend timestamp to message
+	GetLocalTime(& time);
+	_stprintf_s(szTimestamp,_T("%.2d/%.2d/%d %.2d:%.2d:%.2d\t"), 
+		time.wDay, time.wMonth, time.wYear, time.wHour, time.wMinute, time.wSecond);
+	_tcscpy_s(textbuf,szTimestamp);
+	_tcscat_s(textbuf,szText);
+	ps[0] = textbuf;
     EventLogging log;
 	log.AddEventSourceToRegistry(NULL);
 	log.LogIt(1,EventID, ps,1,NULL,0);
@@ -128,12 +134,6 @@ void LOG(long EventID, const TCHAR *format, ...) {
 	file = _tfopen(szMslogonLog, _T("a"));
 	if(file!=NULL) 
 	{
-		// Prepend timestamp to message
-		GetLocalTime(& time);
-		_stprintf_s(szTimestamp,_T("%.2d/%.2d/%d %.2d:%.2d:%.2d  "), 
-			time.wDay, time.wMonth, time.wYear, time.wHour, time.wMinute, time.wSecond);
-		_tcscpy_s(textbuf,szTimestamp);
-		_tcscat_s(textbuf,szText);
 
 		// Write ANSI
 #if defined UNICODE || defined _UNICODE

--- a/addon/ms-logon/authSSP/vncSSP.cpp
+++ b/addon/ms-logon/authSSP/vncSSP.cpp
@@ -90,9 +90,9 @@ int CUPSD(const char * userin, const char *password, const char *machine)
 	//LookupAccountName(NULL, user2, Sid, cbSid, DomainName, cbDomainName, peUse);
 
 	if (isInteract)	{
-		LOG(0x00640001L, _T("Connection received from %s using %s account\n"), machine2, user2);
+		LOG(0x00640001L, _T("Connection received from %s using %s account (Interact)\n"), machine2, user2);
 	} else if (isViewOnly) {
-		LOG(0x00640001L, _T("Connection received from %s using %s account\n"), machine2, user2);
+		LOG(0x00640001L, _T("Connection received from %s using %s account (ViewOnly)\n"), machine2, user2);
 		isAccessOK = 2;
 	} else {
 		LOG(0x00640002L, _T("Invalid attempt (not %s) from client %s using %s account\n"), 

--- a/addon/ms-logon/logging/logging.cpp
+++ b/addon/ms-logon/logging/logging.cpp
@@ -133,7 +133,7 @@ void LOGEXIT(char *machine)
 		SYSTEMTIME time;
 		GetLocalTime(& time);
 		char			szText[256];
-		sprintf(szText,"%d/%d/%d %d:%.2d   ", time.wDay,time.wMonth,time.wYear,time.wHour,time.wMinute );
+		sprintf(szText, "%02d/%02d/%d %02d:%02d:%02d\t", time.wDay, time.wMonth, time.wYear, time.wHour, time.wMinute, time.wSecond);
 		strcpy(texttowrite,szText);
 		strcat(texttowrite,"Client ");
 		strcat(texttowrite,machine);
@@ -171,7 +171,7 @@ void LOGLOGON(char *machine)
 		SYSTEMTIME time;
 		GetLocalTime(& time);
 		char			szText[256];
-		sprintf(szText,"%d/%d/%d %d:%.2d   ", time.wDay,time.wMonth,time.wYear,time.wHour,time.wMinute );
+		sprintf(szText, "%02d/%02d/%d %02d:%02d:%02d\t", time.wDay, time.wMonth, time.wYear, time.wHour, time.wMinute, time.wSecond);
 		strcpy(texttowrite,szText);
 		strcat(texttowrite,"Connection received from ");
 		strcat(texttowrite,machine);
@@ -207,7 +207,7 @@ void LOGFAILED(char *machine)
 		SYSTEMTIME time;
 		GetLocalTime(& time);
 		char			szText[256];
-		sprintf(szText,"%d/%d/%d %d:%.2d   ", time.wDay,time.wMonth,time.wYear,time.wHour,time.wMinute );
+		sprintf(szText, "%02d/%02d/%d %02d:%02d:%02d\t", time.wDay, time.wMonth, time.wYear, time.wHour, time.wMinute, time.wSecond);
 		strcpy(texttowrite,szText);
 		strcat(texttowrite,"Invalid attempt from client ");
 		strcat(texttowrite,machine);
@@ -243,7 +243,7 @@ void LOGLOGONUSER(char *machine,char *user)
 		SYSTEMTIME time;
 		GetLocalTime(& time);
 		char			szText[256];
-		sprintf(szText,"%d/%d/%d %d:%.2d   ", time.wDay,time.wMonth,time.wYear,time.wHour,time.wMinute );
+		sprintf(szText, "%02d/%02d/%d %02d:%02d:%02d\t", time.wDay, time.wMonth, time.wYear, time.wHour, time.wMinute, time.wSecond);
 		strcpy(texttowrite,szText);
 		strcat(texttowrite,"Connection received from ");
 		strcat(texttowrite,machine);
@@ -282,7 +282,7 @@ void LOGFAILEDUSER(char *machine, char *user)
 		SYSTEMTIME time;
 		GetLocalTime(& time);
 		char			szText[256];
-		sprintf(szText,"%d/%d/%d %d:%.2d   ", time.wDay,time.wMonth,time.wYear,time.wHour,time.wMinute );
+		sprintf(szText, "%02d/%02d/%d %02d:%02d:%02d\t", time.wDay, time.wMonth, time.wYear, time.wHour, time.wMinute, time.wSecond);
 		strcpy(texttowrite,szText);
 		strcat(texttowrite,"Invalid attempt from client ");
 		strcat(texttowrite,machine);


### PR DESCRIPTION
- Normalization of log entries ( fixed date formatting )
- Interact/ViewOnly log type for MSLogon.

before:
```
3/2/2023 20:07   Invalid attempt from client WINNOME-E6L6FSO using test.vnc account 
3/2/2023 20:07   Invalid attempt from client WINNOME-E6L6FSO
3/2/2023 20:10   Connection received from WINNOME-E6L6FSO
03/02/2023 20:10:47  Connection received from WINNOME-E6L6FSO using test.vnc account
3/2/2023 20:10   Connection received from WINNOME-E6L6FSO
3/2/2023 20:10   Client WINNOME-E6L6FSO disconnected
3/2/2023 20:52   Connection received from WINNOME-E6L6FSO
03/02/2023 20:52:36  Invalid attempt (not authenticated) from client WINNOME-E6L6FSO using asdfasdf account
3/2/2023 20:52   Invalid attempt from client WINNOME-E6L6FSO
```

After ( PS: system date changed to future to test print formatting ):

```
06/02/2023 21:31:56	Connection received from 2019CORE
06/02/2023 21:32:04	Connection received from 2019CORE using test.vnc2 account (viewOnly)
06/02/2023 21:32:04	Connection received from 2019CORE
06/02/2023 21:32:12	Client 2019CORE disconnected
12/11/2023 22:03:19	Connection received from 2019CORE
12/11/2023 22:03:27	Invalid attempt (not authenticated) from client 2019CORE using test.vnc account
12/11/2023 22:03:27	Invalid attempt from client 2019CORE
12/11/2023 22:03:34	Connection received from 2019CORE
12/11/2023 22:03:41	Connection received from 2019CORE using test.vnc account (Interact)
12/11/2023 22:03:41	Connection received from 2019CORE
12/11/2023 22:03:46	Client 2019CORE disconnected
```

These changes didn't break my regex used in zabbix for VNC activity monitoring.

Just a tiny improvement from a non-developer :)