### PR TITLE
Handle 'Z_STREAM_END' in zlib stream decompression

### DIFF
--- a/rdr/ZlibInStream.cxx
+++ b/rdr/ZlibInStream.cxx
@@ -117,7 +117,7 @@ void ZlibInStream::decompress()
     zs->avail_in = bytesIn;
 
   int rc = inflate(zs, Z_SYNC_FLUSH);
-  if (rc != Z_OK) {
+  if (rc != Z_OK && rc != Z_STREAM_END) {
     throw Exception("ZlibInStream: inflate failed");
   }
 


### PR DESCRIPTION
From zlib manual (https://zlib.net/manual.htm):

"inflate() returns Z_OK if some progress has been made (more input processed or more output produced),  Z_STREAM_END if the end of the compressed data has been reached and all uncompressed output has been produced"

I was testing the Extended Clipboard implementation of LibVNCClient with UltraVNC server.  Calling inflate() on stream sent by client results in Z_STREAM_END, which ultimately results in server crash.
