### PR TITLE
reinit d3d device in preupdate if invalid

### DIFF
--- a/vncviewer/directx/directxviewer.cpp
+++ b/vncviewer/directx/directxviewer.cpp
@@ -523,8 +523,11 @@ ViewerDirectxClass:: Preupdate(unsigned char * bits)
 			break;
 	}
 
-	if (!valid())
+	if (!valid()) {
+		DestroyD3D();
+		if(ReInitD3D() != S_OK)
 			return NULL;
+	}
 	if (directxlocked == true) 
 		return bits;
 #ifdef _DEBUG


### PR DESCRIPTION
this fixes the issue desscribed in https://github.com/ultravnc/UltraVNC/issues/128 for us.

when the vncclient runs on a machine without display and the rdp session used to work on the machine is removed the d3d device seems to get lost and therefore no updates are painted in the vncviewer.

this fix tries to reinitalise the d3d device if this happens.
don't know if it should be handled on more or other places.

i would be glad if you could review and either merge the changes or give a feedback what would be needed to make it work for you.

Best Regards
Joachim D