### PR TITLE
Added "Hide End of Stream Error" option

### DIFF
--- a/vncviewer/ClientConnection.cpp
+++ b/vncviewer/ClientConnection.cpp
@@ -2511,7 +2511,7 @@ void ClientConnection::NegotiateProtocolVersion()
 									"- Another viewer using a DSMPlugin is already connected to the Server (more than one is forbidden)\r\n"
 									,1003
 									);
-		else
+		else if (!m_pApp->m_options.m_HideEndOfStreamError)
 			throw WarningException("Connection failed - End of Stream\r\n\r\n"
 									"Possible causes:\r\r"
 									"- Another user is already listening on this ID\r\n"

--- a/vncviewer/SessionDialog.cpp
+++ b/vncviewer/SessionDialog.cpp
@@ -149,6 +149,7 @@ SessionDialog::SessionDialog(VNCOptions* pOpt, ClientConnection* pCC, CDSMPlugin
 	restricted = m_pOpt->m_restricted;
 	AllowUntrustedServers = m_pOpt->m_AllowUntrustedServers;
 	NoStatus = m_pOpt->m_NoStatus;
+	HideEndOfStreamError = m_pOpt->m_HideEndOfStreamError;
 	NoHotKeys = m_pOpt->m_NoHotKeys;
 	setdefaults = false;
 	/////////////////////////////////////////////////
@@ -699,6 +700,7 @@ bool SessionDialog::connect(HWND hwnd)
 	m_pOpt->m_restricted = restricted;
 	m_pOpt->m_AllowUntrustedServers = AllowUntrustedServers;
 	m_pOpt->m_NoStatus = NoStatus;
+	m_pOpt->m_HideEndOfStreamError = HideEndOfStreamError;
 	m_pOpt->m_NoHotKeys = NoHotKeys;
 
 	if (fUseDSMPlugin) {

--- a/vncviewer/SessionDialog.h
+++ b/vncviewer/SessionDialog.h
@@ -125,6 +125,7 @@ public:
 	bool restricted;
 	bool AllowUntrustedServers;
 	bool NoStatus;
+	bool HideEndOfStreamError;
 	bool NoHotKeys;
 	bool setdefaults;
 	bool connect(HWND hwnd);

--- a/vncviewer/SessionDialogTabs.cpp
+++ b/vncviewer/SessionDialogTabs.cpp
@@ -940,6 +940,8 @@ void SessionDialog::InitDlgProcMisc()
 	SetDlgItemText(hwnd, IDC_PREFIX, prefix);
 	HWND hNoStatus = GetDlgItem(hwnd, IDC_HIDESTATUS);
 	SendMessage(hNoStatus, BM_SETCHECK, NoStatus, 0);
+	HWND hHideEndOfStreamError = GetDlgItem(hwnd, IDC_HIDEENDOFSTREAMERROR);
+	SendMessage(hHideEndOfStreamError, BM_SETCHECK, HideEndOfStreamError, 0);
 	HWND hcomboscreen = GetDlgItem(hwnd, IDC_IMAGEFORMAT);
 	SendMessage(hcomboscreen, CB_RESETCONTENT, 0, 0);
 	SendMessage(hcomboscreen, CB_ADDSTRING, 0, (LPARAM)".jpeg");
@@ -1205,6 +1207,10 @@ void SessionDialog::ReadDlgProcMisc()
 
 	HWND hNoStatus = GetDlgItem(hwnd, IDC_HIDESTATUS);
 	NoStatus = (SendMessage(hNoStatus, BM_GETCHECK, 0, 0) == BST_CHECKED);
+	
+	HWND hHideEndOfStreamError = GetDlgItem(hwnd, IDC_HIDEENDOFSTREAMERROR);
+	HideEndOfStreamError = (SendMessage(hHideEndOfStreamError, BM_GETCHECK, 0, 0) == BST_CHECKED);
+
 	GetDlgItemText(hwnd, IDC_IMAGEFORMAT, imageFormat, 56);
 }
 ////////////////////////////////////////////////////////////////////////////////
@@ -1562,6 +1568,7 @@ void SessionDialog::StartListener()
 	m_pOpt->m_restricted = restricted;
 	m_pOpt->m_AllowUntrustedServers = AllowUntrustedServers;
 	m_pOpt->m_NoStatus = NoStatus;
+	m_pOpt->m_HideEndOfStreamError = HideEndOfStreamError;
 	m_pOpt->m_NoHotKeys = NoHotKeys;
 #ifdef _Gii
 	m_pOpt->m_giiEnable = giiEnable;

--- a/vncviewer/VNCOptions.cpp
+++ b/vncviewer/VNCOptions.cpp
@@ -610,6 +610,9 @@ void VNCOptions::SetFromCommandLine(LPTSTR szCmdLine) {
 		else if (SwitchMatch(args[j], _T("nostatus"))) {
 			m_NoStatus = true;
 		}
+		else if (SwitchMatch(args[j], _T("hideendofstreamerror"))) {
+			m_HideEndOfStreamError = true;
+		}
 		else if (SwitchMatch(args[j], _T("nohotkeys"))) {
 			m_NoHotKeys = true;
 		}
@@ -1355,7 +1358,7 @@ void VNCOptions::ShowUsage(LPTSTR info) {
 			"      [/encodings xz zrle ...]  (in order of priority)\r\n"
 			"      [/autoacceptincoming] [/autoacceptnodsm] [/disablesponsor][/InfoMsg \"Messages need quotes\"]\r\n" //adzm 2009-06-21, adzm 2009-07-19
 			"      [/requireencryption] [/enablecache] [/throttlemouse n] [/socketkeepalivetimeout n]\r\n" //adzm 2010-05-12
-			"      [/gnome]\r\n"
+			"      [/gnome] [/hideendofstreamerror]\r\n"
 			"For full details see documentation."),
 		tmpinf);
 	yesUVNCMessageBox(NULL, msg, sz_A2, MB_ICONINFORMATION);

--- a/vncviewer/VNCOptions.cpp
+++ b/vncviewer/VNCOptions.cpp
@@ -254,6 +254,9 @@ VNCOptions::VNCOptions()
 	m_keepAliveInterval = KEEPALIVE_INTERVAL;
 	m_IdleInterval = 0;
 	m_throttleMouse = 0; // adzm 2010-10
+	
+	m_HideEndOfStreamError = false;
+	
 	setDefaultOptionsFileName(m_optionfile);
 	LoadOptions(getDefaultOptionsFileName());
 }
@@ -1140,6 +1143,7 @@ void VNCOptions::SaveOptions(char* fname)
 	saveInt("AllowUntrustedServers", m_AllowUntrustedServers, fname);
 	saveInt("viewonly", m_ViewOnly, fname);
 	saveInt("nostatus", m_NoStatus, fname);
+	saveInt("HideEOStreamError", m_HideEndOfStreamError, fname);
 	saveInt("nohotkeys", m_NoHotKeys, fname);
 	saveInt("showtoolbar", m_ShowToolbar, fname);
 	saveInt("fullscreen", m_FullScreen, fname);
@@ -1236,6 +1240,7 @@ void VNCOptions::LoadOptions(char* fname)
 	m_AllowUntrustedServers = readInt("AllowUntrustedServers", m_AllowUntrustedServers, fname) != 0;
 	m_ViewOnly = readInt("viewonly", m_ViewOnly, fname) != 0;
 	m_NoStatus = readInt("nostatus", m_NoStatus, fname) != 0;
+	m_HideEndOfStreamError = readInt("HideEOStreamError", m_HideEndOfStreamError, fname) != 0;
 	m_NoHotKeys = readInt("nohotkeys", m_NoHotKeys, fname) != 0;
 	m_ShowToolbar = readInt("showtoolbar", m_ShowToolbar, fname) != 0;
 	m_FullScreen = readInt("fullscreen", m_FullScreen, fname) != 0;

--- a/vncviewer/VNCOptions.h
+++ b/vncviewer/VNCOptions.h
@@ -169,6 +169,8 @@ public:
 	char m_InfoMsg[255]{ 0 };
 	char m_ClassName[255]{ 0 };
 
+	bool m_HideEndOfStreamError;
+
 private:
 	void ShowUsage(LPTSTR info = NULL);
 	void FixScaling();

--- a/vncviewer/res/resource.h
+++ b/vncviewer/res/resource.h
@@ -269,6 +269,7 @@
 #define IDC_PREFIX                      1184
 #define IDC_RADIO3                      1185
 #define IDC_RADIO_NOVIRT                1185
+#define IDC_HIDEENDOFSTREAMERROR        1186
 #define IDC_ENCODING_BASE               1199
 #define IDC_RAWRADIO                    2000
 #define IDC_RRERADIO                    2002

--- a/vncviewer/res/vncviewer.rc
+++ b/vncviewer/res/vncviewer.rc
@@ -662,6 +662,7 @@ BEGIN
     CONTROL         "Do not display the sponsor advertisement",IDC_CHECK1,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,100,164,10
     CONTROL         "Hide status window",IDC_HIDESTATUS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,112,128,10
+    CONTROL         "Hide End of Stream error", IDC_HIDEENDOFSTREAMERROR, "Button", BS_AUTOCHECKBOX | WS_TABSTOP,4,124,164,10
     LTEXT           "Folder",IDC_STATIC,4,18,36,9
     LTEXT           "Prefix",IDC_STATIC,4,36,36,8
     LTEXT           "Snapshot folder and prefix",IDC_STATIC,4,4,232,8

--- a/vncviewer/sessiondialogLoadSave.cpp
+++ b/vncviewer/sessiondialogLoadSave.cpp
@@ -211,6 +211,7 @@ void SessionDialog::SaveToFile(char *fname, bool asDefault)
 	saveInt("restricted",			restricted,		fname);  //hide menu
 	saveInt("AllowUntrustedServers", AllowUntrustedServers, fname);
 	saveInt("nostatus",				NoStatus,			fname); //hide status window
+	saveInt("HideEOStreamError",    HideEndOfStreamError, fname); // hide End of Stream error
 	saveInt("nohotkeys",			NoHotKeys,		fname); //disable hotkeys
 	saveInt("sponsor",				g_disable_sponsor,	fname);
 	saveInt("PreemptiveUpdates",	preemptiveUpdates, fname);


### PR DESCRIPTION
This option removes disables showing the "End of Stream" error.
~~It is not available in GUI or CMD line parameters, currently only by editing options.vnc.~~

Solves this issue: https://github.com/ultravnc/UltraVNC/issues/196