### PR TITLE
Allow coalesced "multi-screen" framebuffer update messages upon `rfbEncodingExtDesktopSize`

### DIFF
--- a/vncviewer/ClientConnection.cpp
+++ b/vncviewer/ClientConnection.cpp
@@ -5850,7 +5850,7 @@ inline void ClientConnection::ReadScreenUpdate()
 		{
 			m_pendingFormatChange = true;
 			ReadNewFBSize(&surh);
-			break;
+			continue;
 		}
 
 		if (surh.encoding == rfbEncodingExtViewSize)
@@ -5863,7 +5863,7 @@ inline void ClientConnection::ReadScreenUpdate()
 			extSDisplay = true;
 			SizeWindow();
 			ScrollScreen(offsetXExtSDisplay, offsetYExtSDisplay, true);
-			break;
+			continue;
 		}
 
 		if (surh.encoding == rfbEncodingExtDesktopSize)
@@ -5905,7 +5905,7 @@ inline void ClientConnection::ReadScreenUpdate()
 			}
 			if (!m_opts->m_GNOME)
 				SendMonitorSizes();
-			break;
+			continue;
 		}
 
 		// Tight cursor handling


### PR DESCRIPTION
Closes #218

Strictly only `rfbEncodingExtDesktopSize` pseudo-encoding was failing with wayvnc but the handlers of `rfbEncodingNewFBSize` and `rfbEncodingExtViewSize` had the same problem when a framebuffer update consisted of multiple "screens".