### PR TITLE
Fix bug in undefer_input() that misplaced the input state.

### DIFF
--- a/zipunzip_src/unzip/fileio.c
+++ b/zipunzip_src/unzip/fileio.c
@@ -479,6 +479,8 @@ void undefer_input(__G)
          * before calling undefer_input() when (G.incnt_leftover > 0)
          * (single exception: see read_byte()'s  "G.csize <= 0" handling) !!
          */
+        if (G.csize < 0L)
+            G.csize = 0L;
         G.incnt = G.incnt_leftover + (int)G.csize;
         G.inptr = G.inptr_leftover - (int)G.csize;
         G.incnt_leftover = 0;


### PR DESCRIPTION
Hi Development Team,

I identified a potential vulnerability in a clone function undefer_input() in `zipunzip_src/unzip/fileio.c`  sourced from [madler/unzip](https://github.com/madler/unzip). This issue, originally reported in [CVE-2019-13232](https://nvd.nist.gov/vuln/detail/CVE-2019-13232), was resolved in the repository via this commit https://github.com/madler/unzip/commit/41beb477c5744bc396fa1162ee0c14218ec12213.

This PR applies the corresponding patch to fix the vulnerability in this codebase.

Please review at your convenience. Thank you!