### PR TITLE
Update French Translation

### DIFF
--- a/translations/vncviewer/French/vncviewer.rc
+++ b/translations/vncviewer/French/vncviewer.rc
@@ -146,19 +146,19 @@ BEGIN
         MENUITEM "Nouvelle connexion",          ID_NEWCONN
         MENUITEM "Options de connexion",        IDC_OPTIONBUTTON
         MENUITEM SEPARATOR
-        MENUITEM "&A propos de UltraVNC Viewer...", IDD_APP_ABOUT
+        MENUITEM "&Ã€ propos d'UltraVNC Viewer...", IDD_APP_ABOUT
         MENUITEM SEPARATOR
-        MENUITEM "Basculer le mode ecoute (On/Off)", ID_LISTEN_MODE
-        MENUITEM "Fermer icone de notification", ID_CLOSEAPP
+        MENUITEM "Activer/DÃ©sactiver le mode Ã©coute", ID_LISTEN_MODE
+        MENUITEM "Fermer l'icÃ´ne de notification", ID_CLOSEAPP
     END
 END
 
 IDR_tbMENU MENU
 BEGIN
-    POPUP "Menu clic droit plein écran"
+    POPUP "Menu clic droit plein Ã©cran"
     BEGIN
         MENUITEM "Restaurer",                   IDC_NULL
-        MENUITEM "Reduire",                     IDC_NULL
+        MENUITEM "RÃ©duire",                     IDC_NULL
         MENUITEM SEPARATOR
         MENUITEM "Fermer",                      IDC_NULL
     END
@@ -172,10 +172,10 @@ END
 
 IDD_OPTIONDIALOG DIALOGEX 0, 0, 335, 253
 STYLE DS_SETFONT | DS_MODALFRAME | DS_SETFOREGROUND | DS_FIXEDSYS | DS_CENTERMOUSE | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "UltraVNC Viewer - Parametres de connexion"
+CAPTION "UltraVNC Viewer - ParamÃ¨tres de connexion"
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
-    CONTROL         "Selection auto des meilleurs parametres",IDC_AUTODETECT,
+    CONTROL         "SÃ©lection auto des meilleurs paramÃ¨tres",IDC_AUTODETECT,
                     "Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_TABSTOP,10,12,136,12
     CONTROL         "ZRLE",IDC_ZRLERADIO,"Button",BS_AUTORADIOBUTTON,12,30,31,10
     CONTROL         "Tight",IDC_TIGHTRADIO,"Button",BS_AUTORADIOBUTTON,48,30,29,10
@@ -197,42 +197,42 @@ BEGIN
     CONTROL         "8 couleurs sombres",IDC_8GREYCOLORS_RADIO,"Button",BS_AUTORADIOBUTTON,89,74,54,10
     CONTROL         "4 niveaux de gris",IDC_4GREYCOLORS_RADIO,"Button",BS_AUTORADIOBUTTON,89,84,67,10
     CONTROL         "Noir && blanc",IDC_2GREYCOLORS_RADIO,"Button",BS_AUTORADIOBUTTON,89,95,57,10
-    CONTROL         "Utiliser encodage CopyRect",ID_SESSION_SET_CRECT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,118,96,10
-    CONTROL         "Utiliser encodage cache",ID_SESSION_SET_CACHE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,128,90,10
+    CONTROL         "Utiliser l'encodage CopyRect",ID_SESSION_SET_CRECT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,118,96,10
+    CONTROL         "Utiliser l'encodage cache",ID_SESSION_SET_CACHE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,128,90,10
     CONTROL         "Compression Zip/Tight",IDC_ALLOW_COMPRESSLEVEL,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,138,87,10
     EDITTEXT        IDC_COMPRESSLEVEL,113,135,14,12,ES_AUTOHSCROLL
-    CONTROL         "JPEG (Tight) - Qualité",IDC_ALLOW_JPEG,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,148,84,10
+    CONTROL         "JPEG (Tight) - QualitÃ©",IDC_ALLOW_JPEG,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,148,84,10
     EDITTEXT        IDC_QUALITYLEVEL,113,148,14,12,ES_AUTOHSCROLL
-    CONTROL         "Mises à jour préventives",IDC_PREEMPTIVEUPDATES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,158,81,10
-    CONTROL         "Partager le serveur",IDC_SHARED,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,196,71,10
-    CONTROL         "Restaurer sur signal sonore",IDC_BELLDEICONIFY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,207,137,8
-    CONTROL         "Desactiver le presse-papiers",IDC_DISABLECLIPBOARD,
+    CONTROL         "Mises Ã  jour anticipÃ©es",IDC_PREEMPTIVEUPDATES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,158,81,10
+    CONTROL         "Mode partagÃ©",IDC_SHARED,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,196,71,10
+    CONTROL         "Restaurer la fenÃªtre sur signal sonore",IDC_BELLDEICONIFY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,207,137,8
+    CONTROL         "DÃ©sactiver la synchronisation du presse-papiers",IDC_DISABLECLIPBOARD,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,216,138,10
-    CONTROL         "Ne pas afficher la publicité",IDC_CHECK1,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,226,145,10
-    CONTROL         "Émuler 3 boutons (clic 2 boutons)",IDC_EMULATECHECK,
+    CONTROL         "Ne pas afficher la publicitÃ©",IDC_CHECK1,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,226,145,10
+    CONTROL         "Ã‰muler 3 boutons (clic 2 boutons)",IDC_EMULATECHECK,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,180,15,139,10
     CONTROL         "Inverser boutons souris 2 et 3",ID_SESSION_SWAPMOUSE,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,180,27,126,10
     CONTROL         "Clavier japonais",IDC_JAPKEYBOARD,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,180,39,78,10
-    CONTROL         "Suivre curseur distant localement",IDC_CSHAPE_ENABLE_RADIO,
+    CONTROL         "Laisser le client gÃ©rer l'affichage du curseur",IDC_CSHAPE_ENABLE_RADIO,
                     "Button",BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,179,52,144,10
-    CONTROL         "Laisser le serveur gérer le curseur",IDC_CSHAPE_DISABLE_RADIO,
+    CONTROL         "Laisser le serveur gÃ©rer l'affichage du curseur",IDC_CSHAPE_DISABLE_RADIO,
                     "Button",BS_AUTORADIOBUTTON,179,63,147,10
-    CONTROL         "Ne pas afficher curseur distant",IDC_CSHAPE_IGNORE_RADIO,
+    CONTROL         "Ne pas afficher le curseur distant",IDC_CSHAPE_IGNORE_RADIO,
                     "Button",BS_AUTORADIOBUTTON,179,74,142,10
     EDITTEXT        IDC_MOUSE_THROTTLE,179,86,22,12,ES_AUTOHSCROLL | ES_NUMBER
-    CONTROL         "Afficher barre de boutons (Toolbar)",IDC_SHOWTOOLBAR,
+    CONTROL         "Afficher la barre d'outils",IDC_SHOWTOOLBAR,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,180,116,138,10
-    CONTROL         "Affichage seul (entrées ignorées)",IDC_VIEWONLY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,180,127,129,10
-    CONTROL         "Mode plein ecran",IDC_FULLSCREEN,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,180,138,114,8
-    CONTROL         "Sauvegarder position",IDC_SAVEPOS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,180,147,79,10
-    CONTROL         "Sauvegarder taille",IDC_SAVESIZE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,270,147,47,10
-    LTEXT           "Taille viewer:",IDC_STATIC,179,161,38,8
+    CONTROL         "Affichage seul (entrÃ©es ignorÃ©es)",IDC_VIEWONLY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,180,127,129,10
+    CONTROL         "Mode plein Ã©cran",IDC_FULLSCREEN,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,180,138,114,8
+    CONTROL         "Sauvegarder la position",IDC_SAVEPOS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,180,147,79,10
+    CONTROL         "Sauvegarder la taille",IDC_SAVESIZE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,270,147,47,10
+    LTEXT           "Taille viewer :",IDC_STATIC,179,161,38,8
     CONTROL         "Auto",IDC_SCALING,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,220,160,27,11
     COMBOBOX        IDC_SCALE_CB,282,159,30,12,CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "Échelle écran serveur",IDC_STATIC,180,174,80,8
+    LTEXT           "Ã‰chelle Ã©cran serveur",IDC_STATIC,180,174,80,8
     EDITTEXT        IDC_SERVER_SCALE,282,173,14,12,ES_AUTOHSCROLL
-    CONTROL         "Adapter a la fenetre",IDC_DIRECTX,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,180,184,85,10
+    CONTROL         "Ajuster Ã  la fenÃªtre",IDC_DIRECTX,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,180,184,85,10
     LTEXT           "tentatives de reconnexion",IDC_STATIC,195,202,75,8
     EDITTEXT        IDC_SERVER_RECON_TIME,276,199,16,14,ES_AUTOHSCROLL | ES_NUMBER
     EDITTEXT        IDC_FTTIMEOUT,251,216,20,14,ES_AUTOHSCROLL
@@ -241,15 +241,15 @@ BEGIN
     GROUPBOX        "Format et encodage",IDC_STATIC,3,2,160,180
     GROUPBOX        "",IDC_STATIC,9,22,72,94
     GROUPBOX        "Divers",IDC_STATIC,3,188,160,52
-    GROUPBOX        "Souris et clavier",IDC_STATIC,174,2,159,100
-    LTEXT           "Limitation événements souris (ms)",IDC_STATIC,205,88,116,11
+    GROUPBOX        "Clavier et souris",IDC_STATIC,174,2,159,100
+    LTEXT           "Intervalle envoi souris (ms)",IDC_STATIC,205,88,116,11
     GROUPBOX        "Affichage",IDC_STATIC,174,104,159,93
     CONTROL         "%",IDC_STATIC,"Static",SS_CENTER | WS_GROUP | 0x20,317,161,8,8
     LTEXT           "1  /",IDC_STATIC,265,175,12,8
     EDITTEXT        IDC_SERVER_RECON,177,199,16,14,ES_AUTOHSCROLL | ES_NUMBER
     GROUPBOX        "",IDC_STATIC,83,22,80,86,WS_GROUP
-    LTEXT           "délai",IDC_STATIC,295,202,25,8
-    LTEXT           "Délai transfert fichier",IDC_STATIC,177,219,65,8
+    LTEXT           "dÃ©lai",IDC_STATIC,295,202,25,8
+    LTEXT           "DÃ©lai transfert fichier",IDC_STATIC,177,219,65,8
     CONTROL         "Utiliser Zstd au lieu de Zlib",IDC_ZSTD,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,168,109,10
     CONTROL         "Pair",IDC_SCALINGEVEN,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,251,160,27,11
 END
@@ -272,17 +272,17 @@ BEGIN
     PUSHBUTTON      "..",IDC_LOCAL_UPB,224,3,17,14
     CONTROL         "",IDC_CURR_LOCAL,"RICHEDIT",TCS_VERTICAL | TCS_RAGGEDRIGHT,3,17,238,12,WS_EX_STATICEDGE
     CONTROL         "List2",IDC_LOCAL_FILELIST,"SysListView32",LVS_REPORT | LVS_SHOWSELALWAYS | LVS_SORTASCENDING | LVS_AUTOARRANGE | WS_BORDER | WS_TABSTOP,3,31,238,324
-    PUSHBUTTON      "Liste lecteurs locaux",IDC_LOCAL_ROOT_B,245,1,66,21,BS_FLAT | NOT WS_VISIBLE
-    PUSHBUTTON      "Liste lecteurs distants",IDC_REMOTE_ROOT_B,246,24,66,21,BS_FLAT | NOT WS_VISIBLE
+    PUSHBUTTON      "Lecteurs locaux",IDC_LOCAL_ROOT_B,245,1,66,21,BS_FLAT | NOT WS_VISIBLE
+    PUSHBUTTON      "Lecteurs distants",IDC_REMOTE_ROOT_B,246,24,66,21,BS_FLAT | NOT WS_VISIBLE
     DEFPUSHBUTTON   "OK",IDOK,246,50,66,14,NOT WS_VISIBLE
     PUSHBUTTON      "Envoyer >>",IDC_UPLOAD_B,246,103,66,14,BS_CENTER | BS_FLAT
     PUSHBUTTON      "<< Recevoir",IDC_DOWNLOAD_B,246,122,66,14,BS_CENTER | BS_FLAT
-    PUSHBUTTON      "Arreter",IDC_ABORT_B,246,141,66,14,BS_FLAT | NOT WS_VISIBLE
+    PUSHBUTTON      "ArrÃªter",IDC_ABORT_B,246,141,66,14,BS_FLAT | NOT WS_VISIBLE
     PUSHBUTTON      "Supprimer",IDC_DELETE_B,246,203,66,14,BS_FLAT
     PUSHBUTTON      "Nouveau dossier",IDC_NEWFOLDER_B,246,221,66,14,BS_FLAT
     PUSHBUTTON      "Renommer",IDC_RENAME_B,246,239,66,14,BS_FLAT
     PUSHBUTTON      "Actualiser",IDC_REFRESH,246,257,66,14,BS_CENTER | BS_FLAT
-    PUSHBUTTON      "Reduire",IDC_HIDE_B,246,306,66,14
+    PUSHBUTTON      "RÃ©duire",IDC_HIDE_B,246,306,66,14
     PUSHBUTTON      "Fermer",IDCANCEL,246,323,66,14
     COMBOBOX        IDC_REMOTE_DRIVECB,314,3,98,172,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     CTEXT           "MACHINE DISTANTE",IDC_RM_STATIC,415,3,95,14,SS_CENTERIMAGE,WS_EX_CLIENTEDGE
@@ -292,8 +292,8 @@ BEGIN
     CONTROL         "List3",IDC_REMOTE_FILELIST,"SysListView32",LVS_REPORT | LVS_SHOWSELALWAYS | LVS_SORTASCENDING | LVS_AUTOARRANGE | WS_BORDER | WS_TABSTOP,314,31,238,324
     LTEXT           "",IDC_GLOBAL_STATUS,484,391,65,8,SS_SUNKEN
     LTEXT           "",IDC_PERCENT,356,388,120,8
-    PUSHBUTTON      "Arrêt forcé",IDC_ABORT_B2,246,160,66,14,BS_FLAT | NOT WS_VISIBLE
-    PUSHBUTTON      "Fermeture forcée",IDCANCEL2,246,340,66,14
+    PUSHBUTTON      "ArrÃªt forcÃ©",IDC_ABORT_B2,246,160,66,14,BS_FLAT | NOT WS_VISIBLE
+    PUSHBUTTON      "Fermeture forcÃ©e",IDCANCEL2,246,340,66,14
 END
 
 IDD_SESSION_DLG DIALOGEX 0, 0, 290, 297
@@ -307,13 +307,13 @@ BEGIN
     PUSHBUTTON      "Options",IDC_BUTTON_EXPAND,9,54,50,13,BS_ICON
     CONTROL         IDB_VNC64,IDC_STATIC,"Static",SS_BITMAP | SS_REALSIZEIMAGE,7,5,26,23
     CONTROL         "Direct",IDC_RADIODIRECT,"Button",BS_AUTORADIOBUTTON | BS_LEFT | BS_VCENTER | WS_GROUP | WS_TABSTOP,83,14,47,10
-    CONTROL         "Répéteur",IDC_RADIOREPEATER,"Button",BS_AUTORADIOBUTTON | BS_LEFT | BS_VCENTER,133,14,47,10
+    CONTROL         "RÃ©pÃ©teur",IDC_RADIOREPEATER,"Button",BS_AUTORADIOBUTTON | BS_LEFT | BS_VCENTER,133,14,47,10
     CONTROL         "",IDC_TAB,"SysTabControl32",TCS_RAGGEDRIGHT | WS_TABSTOP,9,80,273,172
     PUSHBUTTON      "Supprimer",IDC_HOSTNAME_DEL,148,258,60,13
     PUSHBUTTON      "Charger",IDC_LOADPROFILE_B,221,258,60,13
-    PUSHBUTTON      "A propos",IDC_ABOUT,75,277,60,13
+    PUSHBUTTON      "Ã€ propos",IDC_ABOUT,75,277,60,13
     PUSHBUTTON      "Enregistrer sous",IDC_SAVEAS,148,277,60,13
-    PUSHBUTTON      "Valeurs par defaut",IDC_RESET_DEFAULTS,75,258,60,13
+    PUSHBUTTON      "Par dÃ©faut",IDC_RESET_DEFAULTS,75,258,60,13
     PUSHBUTTON      "Enregistrer",IDC_SAVE,221,277,60,13
     COMBOBOX        IDC_LANGUAGE_COMBO,9,277,60,80,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     LTEXT           "Ordinateur",IDC_LINE1,43,28,46,8
@@ -349,10 +349,10 @@ END
 IDD_AUTH_DIALOG2 DIALOGEX 101, 66, 214, 113
 STYLE DS_SETFONT | DS_MODALFRAME | DS_SETFOREGROUND | DS_3DLOOK | DS_FIXEDSYS | DS_CENTER | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_TOPMOST
-CAPTION "UltraVNC Viewer - Authentication - Unsecured Transmission"
+CAPTION "UltraVNC Viewer - Authentification - Transmission non sÃ©curisÃ©e"
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
-    LTEXT           "With the current UltraVNC Viewer version, the password you provide is not transferred securely, except if you are using the encryption DSMPlugin.\r\nPlease update the UltraVNC Server on the remote computer to v1.0.2 or above for secure password transmission.",IDC_STATIC,8,6,196,44
+    LTEXT           "Avec cette version d'UltraVNC Viewer, le mot de passe fourni n'est pas transmis de maniÃ¨re sÃ©curisÃ©e, sauf si vous utilisez le plugin de chiffrement DSM.\r\nVeuillez mettre Ã  jour le serveur UltraVNC sur l'ordinateur distant vers la version v1.0.2 ou supÃ©rieure pour une transmission sÃ©curisÃ©e.",IDC_STATIC,8,6,196,44
     EDITTEXT        IDD_USER_NAME,114,57,92,14,ES_AUTOHSCROLL
     EDITTEXT        IDC_PASSWD_EDIT,114,73,92,14,ES_PASSWORD | ES_AUTOHSCROLL
     DEFPUSHBUTTON   "Connexion",IDOK,95,92,54,15
@@ -365,10 +365,10 @@ END
 IDD_CUSTUM_KEY DIALOGEX 0, 0, 224, 58
 STYLE DS_SETFONT | DS_MODALFRAME | DS_SETFOREGROUND | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_TOPMOST
-CAPTION "UltraVNC Viewer - Send Custom Key (Experimental...)"
+CAPTION "UltraVNC Viewer - Envoyer une touche personnalisÃ©e (ExpÃ©rimental)"
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
-    LTEXT           "Code touche (décimal)",IDC_STATIC,7,9,87,12
+    LTEXT           "Code touche (dÃ©cimal)",IDC_STATIC,7,9,87,12
     EDITTEXT        IDC_CUSTOM_KEY,100,7,51,14,ES_AUTOHSCROLL
     CONTROL         "ALT GR",IDC_ALTGR,"Button",BS_AUTORADIOBUTTON,54,26,38,9
     CONTROL         "CTRL",IDC_STRG,"Button",BS_AUTORADIOBUTTON,100,26,35,9
@@ -380,23 +380,23 @@ END
 
 IDD_STATUS DIALOGEX 0, 0, 214, 201
 STYLE DS_SETFONT | DS_MODALFRAME | DS_SETFOREGROUND | DS_3DLOOK | DS_FIXEDSYS | WS_CAPTION | WS_SYSMENU
-CAPTION "UltraVNC Viewer - Etat de connexion"
+CAPTION "UltraVNC Viewer - Ã‰tat de connexion"
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     DEFPUSHBUTTON   "Fermer",IDCLOSE,157,180,50,14
     GROUPBOX        "Connexion",IDC_STATIC,7,0,199,112
     GROUPBOX        "Trafic",IDC_STATIC,7,112,199,42
     LTEXT           "Port",IDC_STATIC,12,26,46,9
-    LTEXT           "Octets envoyes",IDC_STATIC,12,125,63,9
-    RTEXT           "Octets recus",IDC_STATIC,117,125,68,9
-    RTEXT           "Envoyés",IDC_SEND,11,141,64,9
-    RTEXT           "Reçus",IDC_RECEIVED,117,141,72,9
-    LTEXT           "Numéro de port",IDC_PORT,101,26,101,9
+    LTEXT           "Octets envoyÃ©s",IDC_STATIC,12,125,63,9
+    RTEXT           "Octets reÃ§us",IDC_STATIC,117,125,68,9
+    RTEXT           "EnvoyÃ©s",IDC_SEND,11,141,64,9
+    RTEXT           "ReÃ§us",IDC_RECEIVED,117,141,72,9
+    LTEXT           "NumÃ©ro de port",IDC_PORT,101,26,101,9
     ICON            IDI_NET,IDC_STATIC,93,121,20,20
     LTEXT           "Serveur VNC",IDC_STATIC,11,12,46,9
     LTEXT           "Nom du serveur",IDC_VNCSERVER,101,12,101,9
-    LTEXT           "État",IDC_STATIC,12,54,46,9
-    LTEXT           "Connexion fermee",IDC_STATUS,101,54,105,9
+    LTEXT           "Ã‰tat",IDC_STATIC,12,54,46,9
+    LTEXT           "Connexion fermÃ©e",IDC_STATUS,101,54,105,9
     RTEXT           "",IDC_PLUGIN_STATUS,14,68,192,9
     PUSHBUTTON      "Annuler",IDQUIT,7,180,50,14
     LTEXT           "Vitesse",IDC_STATIC,12,85,31,8
@@ -412,7 +412,7 @@ END
 IDD_AUTH_DIALOG1 DIALOGEX 101, 66, 234, 58
 STYLE DS_SETFONT | DS_MODALFRAME | DS_SETFOREGROUND | DS_3DLOOK | DS_FIXEDSYS | DS_CENTER | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 EXSTYLE WS_EX_TOPMOST
-CAPTION "UltraVNC Viewer - WARNING: Upgrade server..."
+CAPTION "UltraVNC Viewer - AVERTISSEMENT : Mettez Ã  jour le serveur..."
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     EDITTEXT        IDC_PASSWD_EDIT,108,13,110,14,ES_PASSWORD | ES_AUTOHSCROLL
@@ -424,13 +424,13 @@ END
 
 IDD_FTPARAM_DLG DIALOGEX 0, 0, 241, 60
 STYLE DS_SYSMODAL | DS_SETFONT | DS_MODALFRAME | DS_SETFOREGROUND | DS_3DLOOK | DS_FIXEDSYS | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "UltraVNC Viewer - File Transfer Param Dialog"
+CAPTION "UltraVNC Viewer - ParamÃ¨tres de transfert de fichiers"
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     EDITTEXT        IDC_FTPARAM_EDIT,10,21,224,14,ES_AUTOHSCROLL
     DEFPUSHBUTTON   "OK",IDOK,128,42,50,14
     PUSHBUTTON      "Annuler",IDCANCEL,184,42,50,14
-    LTEXT           "File Transfer Param comment. Please enter blah blah blah...",IDC_FTPARAMCOMMENT,9,7,225,8
+    LTEXT           "ParamÃ¨tres du transfert de fichiers. Veuillez saisir un commentaire...",IDC_FTPARAMCOMMENT,9,7,225,8
 END
 
 IDD_TEXTCHAT_DLG DIALOGEX 0, 0, 307, 175
@@ -440,7 +440,7 @@ FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     EDITTEXT        IDC_INPUTAREA_EDIT,4,136,255,36,ES_MULTILINE | ES_AUTOVSCROLL | ES_WANTRETURN | NOT WS_BORDER | WS_VSCROLL,WS_EX_STATICEDGE
     PUSHBUTTON      "Envoyer",IDC_SEND_B,264,135,39,14,BS_CENTER | BS_MULTILINE
-    PUSHBUTTON      "Reduire",IDC_HIDE_B,264,151,39,11
+    PUSHBUTTON      "RÃ©duire",IDC_HIDE_B,264,151,39,11
     PUSHBUTTON      "Fermer",IDCANCEL,264,162,39,11
     CONTROL         "",IDC_CHATAREA_EDIT,"RICHEDIT",TCS_HOTTRACK | TCS_RAGGEDRIGHT | TCS_FOCUSONBUTTONDOWN | TCS_MULTISELECT | WS_VSCROLL | WS_TABSTOP,3,3,300,130,WS_EX_STATICEDGE
     DEFPUSHBUTTON   "",IDOK,299,0,8,6,NOT WS_VISIBLE
@@ -448,17 +448,17 @@ END
 
 IDD_APP_ABOUT DIALOGEX 0, 0, 264, 66
 STYLE DS_SETFONT | DS_MODALFRAME | DS_SETFOREGROUND | DS_FIXEDSYS | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "UltraVNC Viewer - A propos"
+CAPTION "UltraVNC Viewer - Ã€ propos"
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     DEFPUSHBUTTON   "OK",IDOK,198,48,62,14
     CONTROL         IDB_VNC64,IDC_STATIC,"Static",SS_BITMAP | SS_CENTERIMAGE,8,1,34,29
     LTEXT           "UltraVNC Viewer 1.4.4.0-dev",IDC_UVVERSION,44,7,199,11
     LTEXT           "Copyright (C) 2002-2024 UltraVNC Team Members",IDC_STATIC,44,31,184,13
-    LTEXT           "Compilé",IDC_STATIC,44,18,30,11
+    LTEXT           "CompilÃ© le",IDC_STATIC,44,18,30,11
     LTEXT           "BuildTime",IDC_BUILDTIME,78,18,98,11
     LTEXT           "https://uvnc.com",IDC_UVNCCOM,39,54,55,8
-    LTEXT           "Site web:",IDC_STATIC,7,54,29,8
+    LTEXT           "Site web :",IDC_STATIC,7,54,29,8
 END
 
 IDD_FTCONFIRM_DLG DIALOGEX 0, 0, 227, 86
@@ -468,10 +468,10 @@ CAPTION "UltraVNC Viewer"
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     LTEXT           "Confirm message here",IDC_FTPCONFIRMCOMMENT,4,8,163,53
-    DEFPUSHBUTTON   "Yes",IDC_YES_B,4,65,53,14
-    PUSHBUTTON      "Yes for All",IDC_YESALL_B,58,65,53,14
-    PUSHBUTTON      "No",IDC_NO_B,112,65,53,14
-    PUSHBUTTON      "No for all",IDC_NOALL_B,166,65,53,14
+    DEFPUSHBUTTON   "Oui",IDC_YES_B,4,65,53,14
+    PUSHBUTTON      "Oui pour tout",IDC_YESALL_B,58,65,53,14
+    PUSHBUTTON      "Non",IDC_NO_B,112,65,53,14
+    PUSHBUTTON      "Non pour tout",IDC_NOALL_B,166,65,53,14
 END
 
 IDD_APP_MESSAGE2 DIALOGEX 0, 0, 273, 136
@@ -483,16 +483,16 @@ BEGIN
     LTEXT           "Info Message",IDC_Message2,43,35,215,54
     CONTROL         IDB_VNC64,IDC_STATIC,"Static",SS_BITMAP | SS_CENTERIMAGE,5,7,34,29
     LTEXT           "UltraVNC Viewer 1.4.4.0-dev",IDC_UVVERSION2,43,6,199,11
-    LTEXT           "Compilé",IDC_STATIC,43,17,15,10
+    LTEXT           "CompilÃ© le",IDC_STATIC,43,17,15,10
     LTEXT           "BuildTime",IDC_BUILDTIME,68,17,98,10
     LTEXT           "https://forum.uvnc.com",IDC_FORUMHYPERLINK,56,102,102,8
     LTEXT           "https://uvnc.com",IDC_WEBSITE,56,92,94,8
     LTEXT           "https://github.com/ultravnc/ultravnc",IDC_GIT,56,112,144,8
     LTEXT           "https://uvnc.com/downloads/ultravnc.html",IDC_WEBDOWNLOAD,56,121,135,8
-    LTEXT           "Site web:",IDC_STATIC,10,92,38,8
-    LTEXT           "Forum:",IDC_STATIC,10,102,38,8
-    LTEXT           "Git:",IDC_STATIC,10,112,38,8
-    LTEXT           "Téléchargements:",IDC_STATIC,10,121,38,8
+    LTEXT           "Site web :",IDC_STATIC,10,92,38,8
+    LTEXT           "Forum :",IDC_STATIC,10,102,38,8
+    LTEXT           "Git :",IDC_STATIC,10,112,38,8
+    LTEXT           "TÃ©lÃ©chargements :",IDC_STATIC,10,121,38,8
 END
 
 IDD_AUTH_DIALOG3 DIALOGEX 101, 66, 234, 58
@@ -521,7 +521,7 @@ BEGIN
     LTEXT           "Utilisateur",IDC_STATIC,58,9,35,8
     LTEXT           "Mot de passe",IDC_STATIC,58,28,33,8
     CONTROL         IDB_VNC64,IDC_STATIC,"Static",SS_BITMAP,8,6,26,23
-    LTEXT           "Catchphrase",IDC_STATIC,8,47,42,8
+    LTEXT           "Phrase secrÃ¨te",IDC_STATIC,8,47,42,8
     LTEXT           "Signature",IDC_STATIC,8,60,35,8
     LTEXT           "",IDC_CATCHPHRASE,58,47,148,8
     LTEXT           "",IDC_SIGNATURE,58,60,148,8
@@ -538,7 +538,7 @@ BEGIN
     PUSHBUTTON      "Annuler",IDCANCEL,174,59,50,15
     LTEXT           "Mot de passe",IDC_STATIC,65,9,33,8
     CONTROL         IDB_VNC64,IDC_STATIC,"Static",SS_BITMAP | SS_CENTERIMAGE,6,-1,37,30
-    LTEXT           "Catchphrase",IDC_STATIC,14,32,42,8
+    LTEXT           "Phrase secrÃ¨te",IDC_STATIC,14,32,42,8
     LTEXT           "Signature",IDC_STATIC,14,47,35,8
     LTEXT           "",IDC_CATCHPHRASE,65,32,159,8
     LTEXT           "",IDC_SIGNATURE,65,47,159,8
@@ -546,7 +546,7 @@ END
 
 IDD_SESSIONSELECTOR DIALOGEX 0, 0, 316, 183
 STYLE DS_SETFONT | DS_MODALFRAME | DS_SETFOREGROUND | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "UltraVNC Viewer - Selecteur de session"
+CAPTION "UltraVNC Viewer - SÃ©lecteur de session"
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     DEFPUSHBUTTON   "OK",IDOK,205,162,50,14
@@ -566,14 +566,14 @@ BEGIN
     DEFPUSHBUTTON   "OK",IDOK,205,38,50,14
     PUSHBUTTON      "Annuler",IDCANCEL,259,38,50,14
     LTEXT           "Dossier",IDC_STATIC,13,9,24,9
-    LTEXT           "Prefixe",IDC_STATIC,13,28,22,8
+    LTEXT           "PrÃ©fixe",IDC_STATIC,13,28,22,8
 END
 
 IDD_ENCODERS DIALOGEX 0, 0, 240, 145
 STYLE DS_SETFONT | DS_FIXEDSYS | DS_CONTROL | WS_CHILD
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
-    CONTROL         "Auto (réseau stable requis)",IDC_AUTODETECT,"Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_TABSTOP,4,4,217,10
+    CONTROL         "Auto (rÃ©seau stable requis)",IDC_AUTODETECT,"Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_TABSTOP,4,4,217,10
     CONTROL         "Raw",IDC_RAWRADIO,"Button",BS_AUTORADIOBUTTON,14,28,29,10
     CONTROL         "Ultra",IDC_ULTRA,"Button",BS_AUTORADIOBUTTON,54,28,29,10
     CONTROL         "Hextile",IDC_HEXTILERADIO,"Button",BS_AUTORADIOBUTTON,86,28,37,10
@@ -592,49 +592,49 @@ BEGIN
     CONTROL         "8 couleurs sombres",IDC_8GREYCOLORS_RADIO,"Button",BS_AUTORADIOBUTTON,142,61,87,10
     CONTROL         "4 niveaux de gris",IDC_4GREYCOLORS_RADIO,"Button",BS_AUTORADIOBUTTON,142,71,83,10
     CONTROL         "Noir && blanc",IDC_2GREYCOLORS_RADIO,"Button",BS_AUTORADIOBUTTON,142,81,57,10
-    CONTROL         "Zlib compression",IDC_ALLOW_COMPRESSLEVEL,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,114,68,10
+    CONTROL         "Compression Zlib",IDC_ALLOW_COMPRESSLEVEL,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,114,68,10
     EDITTEXT        IDC_COMPRESSLEVEL,87,113,14,12,ES_AUTOHSCROLL
-    CONTROL         "JPEG Quality",IDC_ALLOW_JPEG,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,127,54,10
+    CONTROL         "QualitÃ© JPEG",IDC_ALLOW_JPEG,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,127,54,10
     EDITTEXT        IDC_QUALITYLEVEL,87,126,14,12,ES_AUTOHSCROLL
     CONTROL         "Utiliser Zstd au lieu de Zlib",IDC_ZSTD,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,136,100,97,10
-    CONTROL         "Utiliser encodage CopyRect",ID_SESSION_SET_CRECT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,136,110,97,10
-    CONTROL         "Utiliser encodage cache",ID_SESSION_SET_CACHE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,136,120,97,10
-    CONTROL         "Mises à jour préventives",IDC_PREEMPTIVEUPDATES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,136,130,97,10
-    LTEXT           "CPU élevé, débit plus faible ",IDC_STATIC,8,87,87,8
-    LTEXT           "Faible CPU, haut débit",IDC_STATIC,8,17,80,8
-    LTEXT           "CPU élevé, débit moyen (sans perte)",IDC_STATIC,8,41,119,8
-    LTEXT           "CPU moyen, débit faible (avec perte)",IDC_STATIC,8,64,123,8
+    CONTROL         "Utiliser l'encodage CopyRect",ID_SESSION_SET_CRECT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,136,110,97,10
+    CONTROL         "Utiliser l'encodage cache",ID_SESSION_SET_CACHE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,136,120,97,10
+    CONTROL         "Mises Ã  jour anticipÃ©es",IDC_PREEMPTIVEUPDATES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,136,130,97,10
+    LTEXT           "CPU Ã©levÃ©, dÃ©bit plus faible",IDC_STATIC,8,87,87,8
+    LTEXT           "Faible CPU, haut dÃ©bit",IDC_STATIC,8,17,80,8
+    LTEXT           "CPU Ã©levÃ©, dÃ©bit moyen (sans perte)",IDC_STATIC,8,41,119,8
+    LTEXT           "CPU moyen, dÃ©bit faible (avec perte)",IDC_STATIC,8,64,123,8
 END
 
 IDD_DISPLAY DIALOGEX 0, 0, 240, 145
 STYLE DS_SETFONT | DS_FIXEDSYS | DS_CONTROL | WS_CHILD
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
-    CONTROL         "Résolution serveur",IDC_CHANGESERVER,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,1,100,10
+    CONTROL         "RÃ©solution serveur",IDC_CHANGESERVER,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,1,100,10
     LTEXT           "Petit",IDC_STATIC,19,12,19,8
     CONTROL         "",IDC_SLIDERRES,"msctls_trackbar32",TBS_AUTOTICKS | TBS_ENABLESELRANGE | WS_TABSTOP,43,12,133,11
     CTEXT           "",IDC_RES,181,12,47,8
-    CONTROL         "Tous mes écrans",IDC_ALLMONS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,22,24,157,10
-    CONTROL         "Résolution écran principal",IDC_RADIO_NOVIRT,"Button",BS_AUTORADIOBUTTON,22,35,90,10
-    CONTROL         "Écrans virtuels (Win10 1903+)",IDC_RADIO_ONLY_VIRTUAL,
+    CONTROL         "Tous mes Ã©crans",IDC_ALLMONS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,22,24,157,10
+    CONTROL         "RÃ©solution Ã©cran principal",IDC_RADIO_NOVIRT,"Button",BS_AUTORADIOBUTTON,22,35,90,10
+    CONTROL         "Ã‰crans virtuels (Win10 1903+)",IDC_RADIO_ONLY_VIRTUAL,
                     "Button",BS_AUTORADIOBUTTON,22,45,157,10
-    CONTROL         "Étendre écran (Win10 1903+)",IDC_RADIO_EXTEND,"Button",BS_AUTORADIOBUTTON,22,55,143,10
-    CONTROL         "Afficher extension seule",IDC_SHOW_EXTEND,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,33,65,164,10
-    CONTROL         "Plein écran multi-écrans",IDC_ALLOWSPAN,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,74,141,10
-    CONTROL         "Ajuster écran (sans barres)",IDC_DIRECTX,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,85,103,10
+    CONTROL         "Ã‰tendre l'Ã©cran (Win10 1903+)",IDC_RADIO_EXTEND,"Button",BS_AUTORADIOBUTTON,22,55,143,10
+    CONTROL         "Afficher uniquement l'Ã©cran Ã©tendu",IDC_SHOW_EXTEND,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,33,65,164,10
+    CONTROL         "Plein Ã©cran multi-Ã©crans",IDC_ALLOWSPAN,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,74,141,10
+    CONTROL         "Ajuster Ã  la fenÃªtre (sans barres)",IDC_DIRECTX,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,85,103,10
     CONTROL         "Barre d'outils",IDC_SHOWTOOLBAR,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,96,60,10
-    CONTROL         "Auto-échelle",IDC_SCALING,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,107,64,10
+    CONTROL         "Auto-Ã©chelle",IDC_SCALING,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,107,64,10
     COMBOBOX        IDC_SCALE_CB,69,105,30,117,CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
     CONTROL         "%",IDC_STATIC,"Static",SS_CENTER | WS_GROUP | 0x20,102,107,8,8
-    LTEXT           "Échelle écran serveur",IDC_STATIC,12,119,80,8
+    LTEXT           "Ã‰chelle Ã©cran serveur",IDC_STATIC,12,119,80,8
     LTEXT           "1  /",IDC_STATIC,99,119,12,8
     EDITTEXT        IDC_SERVER_SCALE,115,117,14,12,ES_AUTOHSCROLL
-    CONTROL         "Sauver position",IDC_SAVEPOS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,129,97,10
-    CONTROL         "Démarrer plein écran",IDC_FULLSCREEN,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,139,87,90,10
-    CONTROL         "Auto-échelle (pair)",IDC_SCALINGEVEN,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,139,98,84,10
+    CONTROL         "Sauvegarder la position",IDC_SAVEPOS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,129,97,10
+    CONTROL         "DÃ©marrer en plein Ã©cran",IDC_FULLSCREEN,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,139,87,90,10
+    CONTROL         "Auto-Ã©chelle (pair)",IDC_SCALINGEVEN,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,139,98,84,10
     CONTROL         "",IDC_GNOME,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,139,110,8,11
-    CONTROL         "Sauver taille",IDC_SAVESIZE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,139,129,73,10
-    LTEXT           "GNOME distant \nQEMU",IDC_STATIC,148,111,82,17
+    CONTROL         "Sauvegarder la taille",IDC_SAVESIZE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,139,129,73,10
+    LTEXT           "GNOME distant /\nQEMU",IDC_STATIC,148,111,82,17
 END
 
 IDD_MISC DIALOGEX 0, 0, 240, 145
@@ -648,16 +648,16 @@ BEGIN
     EDITTEXT        IDC_SERVER_RECON,100,59,16,14,ES_AUTOHSCROLL | ES_NUMBER
     EDITTEXT        IDC_SERVER_RECON_TIME,169,59,16,14,ES_AUTOHSCROLL | ES_NUMBER
     EDITTEXT        IDC_FTTIMEOUT,100,79,16,14,ES_AUTOHSCROLL
-    CONTROL         "Ne pas afficher la publicité",IDC_CHECK1,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,100,164,10
-    CONTROL         "Masquer fenêtre statut",IDC_HIDESTATUS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,112,128,10
-    CONTROL         "Masquer erreur fin de flux",IDC_HIDEENDOFSTREAMERROR,
+    CONTROL         "Ne pas afficher la publicitÃ©",IDC_CHECK1,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,100,164,10
+    CONTROL         "Masquer la fenÃªtre de statut",IDC_HIDESTATUS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,112,128,10
+    CONTROL         "Masquer l'erreur de fin de flux",IDC_HIDEENDOFSTREAMERROR,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,124,164,10
     LTEXT           "Dossier",IDC_STATIC,4,18,36,9
-    LTEXT           "Prefixe",IDC_STATIC,4,36,36,8
-    LTEXT           "Dossier et préfixe capture",IDC_STATIC,4,4,232,8
+    LTEXT           "PrÃ©fixe",IDC_STATIC,4,36,36,8
+    LTEXT           "Dossier et prÃ©fixe de capture",IDC_STATIC,4,4,232,8
     LTEXT           "tentatives de reconnexion",IDC_STATIC,4,62,89,8
-    LTEXT           "délai",IDC_STATIC,130,62,34,8
-    LTEXT           "Délai transfert fichier",IDC_STATIC,4,82,87,8
+    LTEXT           "dÃ©lai",IDC_STATIC,130,62,34,8
+    LTEXT           "DÃ©lai transfert fichier",IDC_STATIC,4,82,87,8
 END
 
 IDD_SECURITY DIALOGEX 0, 0, 240, 145
@@ -666,17 +666,17 @@ FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     CONTROL         "Utiliser le chiffrement",IDC_PLUGIN_CHECK,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,8,82,10
     COMBOBOX        IDC_PLUGINS_COMBO,93,6,138,55,CBS_DROPDOWN | CBS_SORT | WS_VSCROLL | WS_TABSTOP
-    PUSHBUTTON      "Configurer plugins chiffrement",IDC_PLUGIN_BUTTON,93,20,138,12
-    CONTROL         "Serveurs chiffrés uniquement",IDC_ONLYENCRYPTED,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,35,112,10
-    CONTROL         "Partager le serveur",IDC_SHARED,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,45,163,10
-    CONTROL         "Desactiver le presse-papiers",IDC_DISABLECLIPBOARD,
+    PUSHBUTTON      "Configurer le plugin de chiffrement",IDC_PLUGIN_BUTTON,93,20,138,12
+    CONTROL         "Serveurs chiffrÃ©s uniquement",IDC_ONLYENCRYPTED,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,35,112,10
+    CONTROL         "Mode partagÃ©",IDC_SHARED,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,45,163,10
+    CONTROL         "DÃ©sactiver la synchronisation du presse-papiers",IDC_DISABLECLIPBOARD,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,55,171,10
-    CONTROL         "Accepter auto (mode écoute)",IDC_AUTOACCEPT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,65,178,10
-    CONTROL         "Ignorer avertissement chiffrement (écoute)",IDC_AUTOACCEPTNOWARN,
+    CONTROL         "Accepter automatiquement (mode Ã©coute)",IDC_AUTOACCEPT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,65,178,10
+    CONTROL         "Ignorer les avertissements de chiffrement en mode Ã©coute",IDC_AUTOACCEPTNOWARN,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,75,201,10
-    CONTROL         "Masquer menu",IDC_HIDEMENU,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,85,109,10
+    CONTROL         "Masquer le menu",IDC_HIDEMENU,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,85,109,10
     EDITTEXT        IDC_EDITCUSTOMMESSAGE,4,116,232,25,ES_MULTILINE
-    LTEXT           "Notification à la connexion",IDC_STATIC,4,108,75,8
+    LTEXT           "Notification Ã  la connexion",IDC_STATIC,4,108,75,8
     CONTROL         "Serveurs avec mot de passe",IDC_ONLYPASSWORD,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,125,35,104,10
     CONTROL         "Utiliser IPv6",IDC_IPV6,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,95,108,10
 END
@@ -685,20 +685,20 @@ IDD_KEYBOARDMOUSE DIALOGEX 0, 0, 240, 145
 STYLE DS_SETFONT | DS_FIXEDSYS | DS_CONTROL | WS_CHILD
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
-    CONTROL         "Suivre curseur distant localement",IDC_CSHAPE_ENABLE_RADIO,
+    CONTROL         "Laisser le client gÃ©rer l'affichage du curseur",IDC_CSHAPE_ENABLE_RADIO,
                     "Button",BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,6,8,144,10
-    CONTROL         "Laisser le serveur gérer le curseur",IDC_CSHAPE_DISABLE_RADIO,
+    CONTROL         "Laisser le serveur gÃ©rer l'affichage du curseur",IDC_CSHAPE_DISABLE_RADIO,
                     "Button",BS_AUTORADIOBUTTON,6,19,147,10
-    CONTROL         "Ne pas afficher curseur distant",IDC_CSHAPE_IGNORE_RADIO,
+    CONTROL         "Ne pas afficher le curseur distant",IDC_CSHAPE_IGNORE_RADIO,
                     "Button",BS_AUTORADIOBUTTON,6,30,142,10
-    CONTROL         "Affichage seul, sans entrée",IDC_VIEWONLY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,47,129,10
-    CONTROL         "Désactiver raccourcis",IDC_NOHOTKEYS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,58,92,10
-    CONTROL         "Émuler 3 boutons (clic 2 boutons)",IDC_EMULATECHECK,
+    CONTROL         "Affichage seul (sans contrÃ´le distant)",IDC_VIEWONLY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,47,129,10
+    CONTROL         "DÃ©sactiver les raccourcis clavier",IDC_NOHOTKEYS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,58,92,10
+    CONTROL         "Ã‰muler 3 boutons (clic 2 boutons)",IDC_EMULATECHECK,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,69,139,10
     CONTROL         "Inverser boutons souris 2 et 3",ID_SESSION_SWAPMOUSE,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,80,126,10
     CONTROL         "Clavier japonais",IDC_JAPKEYBOARD,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,91,78,10
-    LTEXT           "Limite événements souris (ms)",IDC_STATIC,6,106,89,11
+    LTEXT           "Intervalle envoi souris (ms)",IDC_STATIC,6,106,89,11
     EDITTEXT        IDC_MOUSE_THROTTLE,106,104,42,12,ES_AUTOHSCROLL | ES_NUMBER
     CONTROL         "Gii",IDC_GII,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,117,24,10
 END
@@ -707,14 +707,14 @@ IDD_QUICKOPTIONS DIALOGEX 0, 0, 240, 145
 STYLE DS_SETFONT | DS_FIXEDSYS | DS_CONTROL | WS_CHILD
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
-    CONTROL         "AUTO (Sélection auto)",IDC_DYNAMIC,"Button",BS_AUTORADIOBUTTON,9,14,177,10
-    CONTROL         "VIDEO (> 2Mbit/s)",IDC_ULTRA_LAN_RB,"Button",BS_AUTORADIOBUTTON,9,28,176,10
-    CONTROL         "LAN (> 1Mbit/s) - Max couleurs",IDC_LAN_RB,"Button",BS_AUTORADIOBUTTON,9,42,176,10
-    CONTROL         "MEDIUM (128-256Kbit/s) - 256 couleurs",IDC_MEDIUM_RB,
+    CONTROL         "AUTO (SÃ©lection automatique)",IDC_DYNAMIC,"Button",BS_AUTORADIOBUTTON,9,14,177,10
+    CONTROL         "VIDEO (> 2 Mbit/s)",IDC_ULTRA_LAN_RB,"Button",BS_AUTORADIOBUTTON,9,28,176,10
+    CONTROL         "LAN (> 1 Mbit/s) - Toutes les couleurs",IDC_LAN_RB,"Button",BS_AUTORADIOBUTTON,9,42,176,10
+    CONTROL         "MOYEN (128-256 Kbit/s) - 256 couleurs",IDC_MEDIUM_RB,
                     "Button",BS_AUTORADIOBUTTON,9,56,153,10
-    CONTROL         "MODEM (19-128Kbit/s) - 64 couleurs",IDC_MODEM_RB,"Button",BS_AUTORADIOBUTTON,9,70,148,10
-    CONTROL         "SLOW (< 19Kbit/s) - 8 couleurs",IDC_SLOW_RB,"Button",BS_AUTORADIOBUTTON,9,84,128,10
-    CONTROL         "MANUEL (Utiliser Options)",IDC_MANUAL,"Button",BS_AUTORADIOBUTTON,9,98,123,10
+    CONTROL         "MODEM (19-128 Kbit/s) - 64 couleurs",IDC_MODEM_RB,"Button",BS_AUTORADIOBUTTON,9,70,148,10
+    CONTROL         "LENT (< 19 Kbit/s) - 8 couleurs",IDC_SLOW_RB,"Button",BS_AUTORADIOBUTTON,9,84,128,10
+    CONTROL         "MANUEL (Utiliser les options)",IDC_MANUAL,"Button",BS_AUTORADIOBUTTON,9,98,123,10
 END
 
 IDD_LISTEN DIALOGEX 0, 0, 240, 145
@@ -722,8 +722,8 @@ STYLE DS_SETFONT | DS_FIXEDSYS | DS_CONTROL | WS_CHILD
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     EDITTEXT        IDC_LISTENPORT,23,24,40,14,ES_AUTOHSCROLL
-    DEFPUSHBUTTON   "Demarrer ecoute",IDC_STARTLISTEN,169,121,61,14
-    LTEXT           "Listen mode",IDC_STATIC,4,10,39,8
+    DEFPUSHBUTTON   "DÃ©marrer l'Ã©coute",IDC_STARTLISTEN,169,121,61,14
+    LTEXT           "Mode Ã©coute",IDC_STATIC,4,10,39,8
     LTEXT           "Port",IDC_STATIC,4,27,17,8
 END
 
@@ -733,8 +733,8 @@ FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     LTEXT           "1",IDC_DEFAULTCONFIG,4,49,232,13
     CONTROL         "Utiliser uniquement options.vnc",IDC_CHECKCONFIG,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,7,82,10
-    LTEXT           "Fichier config par défaut",IDC_SLIDERRES,4,35,124,8
-    LTEXT           "Fichier config personnalisé",IDC_STATIC,4,66,110,8
+    LTEXT           "Fichier de configuration par dÃ©faut",IDC_SLIDERRES,4,35,124,8
+    LTEXT           "Fichier de configuration personnalisÃ©",IDC_STATIC,4,66,110,8
     LTEXT           "2",IDC_CUSTOMCONFIG,4,79,232,18
 END
 
@@ -1192,415 +1192,415 @@ END
 
 STRINGTABLE
 BEGIN
-    IDR_TRAY                "UltraVNC Viewer listening"
+    IDR_TRAY                "UltraVNC Viewer en Ã©coute"
 END
 
 STRINGTABLE
 BEGIN
-    ID_BUTTON_DINPUT        "Désactiver boutons"
-    ID_BUTTON_DBUTTON       "Désactiver souris et clavier serveur"
-    ID_BUTTON_SW            "Sélectionner SW"
-    ID_BUTTON_DESKTOP       "Sélectionner Bureau"
-    IDS_WARNING             "AVERTISSEMENT: Par défaut, cette session n'utilise aucun chiffrement. Ne l'utilisez pas pour envoyer des données sensibles sauf si vous êtes sûr que votre connexion est sécurisée (en utilisant un plugin de chiffrement, par exemple).\n\n"
-    IDS_A1                  "Arrêter le systray du viewer"
+    ID_BUTTON_DINPUT        "DÃ©sactiver les boutons"
+    ID_BUTTON_DBUTTON       "DÃ©sactiver la souris et le clavier du serveur"
+    ID_BUTTON_SW            "SÃ©lectionner SW"
+    ID_BUTTON_DESKTOP       "SÃ©lectionner le bureau"
+    IDS_WARNING             "AVERTISSEMENT : Par dÃ©faut, cette session n'utilise aucun chiffrement. Ne l'utilisez pas pour transmettre des donnÃ©es sensibles, sauf si vous Ãªtes certain que votre connexion est sÃ©curisÃ©e (via un plugin de chiffrement, par exemple).\n\n"
+    IDS_A1                  "ArrÃªter le systray du viewer"
     IDS_A2                  "Info UltraVNC"
-    IDS_A3                  "Erreur lors de la création du démon d'écoute:\n\r"
-    IDS_A4                  "Peut-être qu'un autre UltraVNC Viewer est déjà en cours d'exécution?"
+    IDS_A3                  "Erreur lors de la crÃ©ation du dÃ©mon d'Ã©coute :\n\r"
+    IDS_A4                  "Un autre UltraVNC Viewer est peut-Ãªtre dÃ©jÃ  en cours d'exÃ©cution."
     IDS_A5                  "Erreur VNC Viewer"
-    IDS_B1                  "Erreur d'initialisation de la bibliothèque sockets"
-    IDS_B2                  "Débordement de la liste des clients!"
+    IDS_B1                  "Erreur d'initialisation de la bibliothÃ¨que sockets"
+    IDS_B2                  "DÃ©bordement de la liste des clients !"
     IDS_B3                  "Erreur VNC"
 END
 
 STRINGTABLE
 BEGIN
-    ID_CLOSEDAEMON          "Arrêter écoute connexions"
-    ID_SHOWWINDOW           "Afficher fenêtre connexion"
+    ID_CLOSEDAEMON          "ArrÃªter l'Ã©coute des connexions"
+    ID_SHOWWINDOW           "Afficher la fenÃªtre de connexion"
     ID_NEWCONN              "Connexion manuelle"
-    ID_BUTTON_CAD           "Envoyer CTRL+ALT+DEL"
-    ID_BUTTON_FTRANS        "Transfert fichiers"
+    ID_BUTTON_CAD           "Envoyer Ctrl+Alt+Suppr"
+    ID_BUTTON_FTRANS        "Transfert de fichiers"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_H101                "Avertissement transfert de dossier"
-    IDS_H102                "Un fichier ou dossier portant ce nom existe déjà."
-    IDS_L94                 "Le serveur a fermé la connexion"
-    IDS_STRING50275         "Le serveur ne prend pas en charge le chiffrement, malgré la demande du viewer."
-    IDS_STRING50276         "Voulez-vous continuer?"
-    IDS_STRING50277         "Accepter connexion non sécurisée"
-    IDS_STRING50278         "Refuser connexion non sécurisée"
-    IDS_STRING50279         "Ne plus demander, toujours autoriser connexion non sécurisée."
-    IDS_STRING50280         "Accepter connexion entrante"
-    IDS_STRING50281         "Refuser connexion entrante"
+    IDS_H101                "Avertissement de transfert de dossier"
+    IDS_H102                "Un fichier ou dossier portant ce nom existe dÃ©jÃ ."
+    IDS_L94                 "Le serveur a fermÃ© la connexion"
+    IDS_STRING50275         "Le serveur ne prend pas en charge le chiffrement, malgrÃ© la demande du viewer."
+    IDS_STRING50276         "Voulez-vous continuer ?"
+    IDS_STRING50277         "Accepter la connexion non sÃ©curisÃ©e"
+    IDS_STRING50278         "Refuser la connexion non sÃ©curisÃ©e"
+    IDS_STRING50279         "Ne plus demander, toujours autoriser les connexions non sÃ©curisÃ©es."
+    IDS_STRING50280         "Accepter la connexion entrante"
+    IDS_STRING50281         "Refuser la connexion entrante"
     IDS_STRING50282         "Connexion entrante"
-    IDS_STRING50283         "Le serveur est configuré sans authentification. Faire confiance?"
+    IDS_STRING50283         "Le serveur est configurÃ© sans authentification. Faire confiance ?"
     IDS_STRING50284         "Faire confiance et se connecter sans authentification"
     IDS_STRING50285         "Ne pas se connecter"
-    IDS_STRING50286         "Sécurité"
+    IDS_STRING50286         "SÃ©curitÃ©"
     IDS_STRING50287         "Oui, je veux sauvegarder le mot de passe"
 END
 
 STRINGTABLE
 BEGIN
     IDS_STRING50288         "Non, sauvegarder sans mot de passe"
-    IDS_STRING50289         "Le serveur tente de surcharger un tampon mémoire, possible exploit."
-    IDS_STRING50290         "Error"
+    IDS_STRING50289         "Le serveur tente de dÃ©border un tampon mÃ©moire â€” exploit possible."
+    IDS_STRING50290         "Erreur"
     IDS_STRING50293         "Essayer de continuer"
     IDS_STRING50294         "Quitter"
-    IDS_STRING50295         "Transfert interrompu: Connexion serveur perdue"
-    IDS_STRING50296         "Warning"
-    IDS_STRING50297         "Le serveur envoie une taille d'écran excessive"
-    IDS_TLS1                "Connexion fermée"
-    IDS_TLS2                "AcquireCredentialsHandle échoué"
-    IDS_TLS3                "QueryContextAttributes échoué"
+    IDS_STRING50295         "Transfert interrompu : connexion au serveur perdue"
+    IDS_STRING50296         "Avertissement"
+    IDS_STRING50297         "Le serveur envoie une taille d'Ã©cran excessive"
+    IDS_TLS1                "Connexion fermÃ©e"
+    IDS_TLS2                "Ã‰chec de AcquireCredentialsHandle"
+    IDS_TLS3                "Ã‰chec de QueryContextAttributes"
     IDS_TLS4                "Tampons E/S insuffisants"
-    IDS_TLS5                "Négociation interrompue"
-    IDS_TLS6                "Négociation impossible"
+    IDS_TLS5                "NÃ©gociation interrompue"
+    IDS_TLS6                "NÃ©gociation impossible"
 END
 
 STRINGTABLE
 BEGIN
-    IDC_OPTIONBUTTON        "Set the options to be used for new connections"
+    IDC_OPTIONBUTTON        "DÃ©finir les options pour les nouvelles connexions"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_C1                  "Échec ouverture presse-papiers\n"
-    IDS_C2                  "Échec vidage presse-papiers\n"
-    IDS_C3                  "Échec fermeture presse-papiers\n"
+    IDS_C1                  "Ã‰chec Ã  l'ouverture du presse-papiers\n"
+    IDS_C2                  "Ã‰chec au vidage du presse-papiers\n"
+    IDS_C3                  "Ã‰chec Ã  la fermeture du presse-papiers\n"
     IDS_D1                  "Erreur d'argument"
-    IDS_D2                  "Facteur d'échelle invalide - réinitialisation"
-    IDS_D3                  "Port d'écoute invalide"
-    IDS_D4                  "Aucun facteur d'échelle spécifié"
-    IDS_D5                  "Échelle invalide spécifiée"
-    IDS_D6                  "Aucun délai spécifié"
-    IDS_D7                  "Délai invalide spécifié"
-    IDS_D8                  "Aucun fuzz spécifié"
-    IDS_D9                  "Fuzz invalide spécifié"
-    IDS_D10                 "Aucun délai spécifié"
-    IDS_D11                 "Délai invalide spécifié"
-    IDS_D12                 "Aucun niveau log spécifié"
-    IDS_D13                 "Niveau log invalide"
+    IDS_D2                  "Facteur d'Ã©chelle invalide - rÃ©initialisation"
+    IDS_D3                  "Port d'Ã©coute invalide"
+    IDS_D4                  "Aucun facteur d'Ã©chelle spÃ©cifiÃ©"
+    IDS_D5                  "Ã‰chelle invalide spÃ©cifiÃ©e"
+    IDS_D6                  "Aucun dÃ©lai spÃ©cifiÃ©"
+    IDS_D7                  "DÃ©lai invalide spÃ©cifiÃ©"
+    IDS_D8                  "Aucun fuzz spÃ©cifiÃ©"
+    IDS_D9                  "Fuzz invalide spÃ©cifiÃ©"
+    IDS_D10                 "Aucun dÃ©lai spÃ©cifiÃ©"
+    IDS_D11                 "DÃ©lai invalide spÃ©cifiÃ©"
+    IDS_D12                 "Aucun niveau de log spÃ©cifiÃ©"
+    IDS_D13                 "Niveau de log invalide"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_D14                 "Aucun fichier log spécifié"
-    IDS_D15                 "Fichier log invalide"
-    IDS_D16                 "Aucun fichier config spécifié"
-    IDS_D17                 "Impossible d'ouvrir le fichier config"
-    IDS_D18                 "Aucun encodage spécifié"
-    IDS_D19                 "Encodage invalide spécifié"
-    IDS_D20                 "Aucun niveau compression spécifié"
-    IDS_D21                 "Niveau compression invalide"
-    IDS_D22                 "Aucun niveau qualité image spécifié"
-    IDS_D23                 "Niveau qualité image invalide"
-    IDS_D24                 "Aucun mot de passe spécifié"
-    IDS_D25                 "Aucun dénominateur échelle serveur"
-    IDS_D26                 "Aucun numéro option rapide"
-    IDS_D27                 "Aucun plugin DSM spécifié"
+    IDS_D14                 "Aucun fichier de log spÃ©cifiÃ©"
+    IDS_D15                 "Fichier de log invalide"
+    IDS_D16                 "Aucun fichier de configuration spÃ©cifiÃ©"
+    IDS_D17                 "Impossible d'ouvrir le fichier de configuration"
+    IDS_D18                 "Aucun encodage spÃ©cifiÃ©"
+    IDS_D19                 "Encodage invalide spÃ©cifiÃ©"
+    IDS_D20                 "Aucun niveau de compression spÃ©cifiÃ©"
+    IDS_D21                 "Niveau de compression invalide"
+    IDS_D22                 "Aucun niveau de qualitÃ© d'image spÃ©cifiÃ©"
+    IDS_D23                 "Niveau de qualitÃ© d'image invalide"
+    IDS_D24                 "Aucun mot de passe spÃ©cifiÃ©"
+    IDS_D25                 "Aucun dÃ©nominateur d'Ã©chelle serveur"
+    IDS_D26                 "Aucun numÃ©ro d'option rapide"
+    IDS_D27                 "Aucun plugin DSM spÃ©cifiÃ©"
     IDS_D28                 "Serveur VNC invalide."
-    IDS_E1                  "Impossible de charger Rich Edit (RICHED32.DLL)!"
+    IDS_E1                  "Impossible de charger Rich Edit (RICHED32.DLL) !"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_E2                  "Chargement Rich Edit Dll"
-    IDS_F1                  "Le plugin ne peut pas être chargé.\n\rVérifiez son intégrité."
+    IDS_E2                  "Chargement de Rich Edit Dll"
+    IDS_F1                  "Le plugin ne peut pas Ãªtre chargÃ©.\n\rVÃ©rifiez son intÃ©gritÃ©."
     IDS_F3                  "Activation du plugin"
     IDS_F4                  "SansMdp,viewer"
-    IDS_F5                  "Le plugin ne peut pas être chargé.\n\rVérifiez le nom."
+    IDS_F5                  "Le plugin ne peut pas Ãªtre chargÃ©.\n\rVÃ©rifiez le nom."
     IDS_F6                  "Chargement du plugin"
-    IDS_F7                  "Le plugin ne peut pas être initialisé.\n\rVérifiez le nom."
-    IDS_F8                  "Serveur VNC invalide.\n\rFormat: hôte:affichage."
-    IDS_F10                 "Configuration connexion"
-    IDS_F11                 "Aucun plugin détecté..."
-    IDS_G1                  "Erreur création socket Flasher"
-    IDS_G2                  "Erreur liaison socket Flasher"
-    IDS_G3                  "Erreur écoute Flasher"
-    IDS_H1                  "> ATTENTION: Transfert fichiers désactivé sur la machine distante"
+    IDS_F7                  "Le plugin ne peut pas Ãªtre initialisÃ©.\n\rVÃ©rifiez le nom."
+    IDS_F8                  "Serveur VNC invalide.\n\rFormat : hÃ´te:numÃ©ro d'affichage."
+    IDS_F10                 "Configuration de la connexion"
+    IDS_F11                 "Aucun plugin dÃ©tectÃ©..."
+    IDS_G1                  "Erreur Ã  la crÃ©ation du socket Flasher"
+    IDS_G2                  "Erreur Ã  la liaison du socket Flasher"
+    IDS_G3                  "Erreur Ã  l'Ã©coute du Flasher"
+    IDS_H1                  "> ATTENTION : Transfert de fichiers dÃ©sactivÃ© sur la machine distante"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_H2                  "> ATTENTION: Transfert fichiers désactivé sur la machine distante"
-    IDS_H3                  "Transfert refusé: désactivé ou utilisateur inconnu ou version incompatible"
-    IDS_H4                  "Connected..."
+    IDS_H2                  "> ATTENTION : Transfert de fichiers dÃ©sactivÃ© sur la machine distante"
+    IDS_H3                  "Transfert refusÃ© : dÃ©sactivÃ©, utilisateur inconnu ou version incompatible"
+    IDS_H4                  "ConnectÃ©..."
     IDS_H5                  "Transfert interrompu par l'utilisateur"
-    IDS_H6                  "Transfert terminé"
+    IDS_H6                  "Transfert terminÃ©"
     IDS_H7                  "Transfert interrompu par l'utilisateur"
-    IDS_H8                  "> Parcours répertoire local. Patientez..."
-    IDS_H9                  "> ERREUR: Aucun média dans le lecteur local."
-    IDS_H10                 "> ERREUR: Aucun média dans le lecteur distant."
-    IDS_H11                 "> Parcours répertoire distant. Patientez..."
-    IDS_H12                 "ERROR: File"
-    IDS_H13                 "is not accessible on Remote Machine"
-    IDS_H14                 "ERROR: Insufficient free space on Local Drive for"
-    IDS_H15                 "Receiving File"
-    IDS_H16                 "cannot be created on Local Machine"
-    IDS_H17                 "File"
+    IDS_H8                  "> Parcours du rÃ©pertoire local. Veuillez patienter..."
+    IDS_H9                  "> ERREUR : Aucun mÃ©dia dans le lecteur local."
+    IDS_H10                 "> ERREUR : Aucun mÃ©dia dans le lecteur distant."
+    IDS_H11                 "> Parcours du rÃ©pertoire distant. Veuillez patienter..."
+    IDS_H12                 "ERREUR : Fichier"
+    IDS_H13                 "inaccessible sur la machine distante"
+    IDS_H14                 "ERREUR : Espace insuffisant sur le lecteur local pour"
+    IDS_H15                 "RÃ©ception du fichier"
+    IDS_H16                 "ne peut pas Ãªtre crÃ©Ã© sur la machine locale"
+    IDS_H17                 "Fichier"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_M1                  "Un seul fichier ou dossier peut être renommé à la fois"
-    IDS_M2                  "Avertissement renommage fichier/dossier"
+    IDS_M1                  "Un seul fichier ou dossier peut Ãªtre renommÃ© Ã  la fois"
+    IDS_M2                  "Avertissement de renommage"
     IDS_M3                  "Renommer fichier/dossier"
-    IDS_M4                  "Entrez le nouveau nom:"
-    IDS_M5                  "ERREUR: Échec renommage "
-    IDS_M6                  "Renommé LOCAL"
+    IDS_M4                  "Entrez le nouveau nom :"
+    IDS_M5                  "ERREUR : Ã‰chec du renommage de "
+    IDS_M6                  "RenommÃ© en LOCAL"
     IDS_M7                  "en"
-    IDS_M8                  "Renommé DISTANT"
-    IDS_H94                 "Avertissement suppression dossier"
+    IDS_M8                  "RenommÃ© en DISTANT"
+    IDS_H94                 "Avertissement de suppression de dossier"
     IDS_H95                 "Voulez-vous supprimer le dossier LOCAL"
     IDS_H96                 "Voulez-vous supprimer le dossier DISTANT"
     IDS_H97                 "Impossible de supprimer le dossier local"
     IDS_H98                 "Impossible de supprimer le dossier distant"
     IDS_H99                 "Impossible de supprimer le dossier"
-    IDS_H100                "Créer nouveau dossier"
+    IDS_H100                "CrÃ©er un nouveau dossier"
     IDS_L93                 "Affichage seul... \tCtrl+Alt+F3"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_H18                 "reçu avec succès..."
-    IDS_H19                 "ERREUR: Transfert du fichier"
-    IDS_H20                 "échoué sur machine distante. Annulé."
-    IDS_H21                 "ERREUR: Problème d'accès au fichier"
+    IDS_H18                 "reÃ§u avec succÃ¨s..."
+    IDS_H19                 "ERREUR : Transfert du fichier"
+    IDS_H20                 "Ã©chouÃ© sur la machine distante. AnnulÃ©."
+    IDS_H21                 "ERREUR : ProblÃ¨me d'accÃ¨s au fichier"
     IDS_H22                 "Envoi du fichier"
-    IDS_H23                 "ERREUR: Problème d'accès au fichier"
-    IDS_H24                 "ne peut être créé sur machine distante"
-    IDS_H25                 "ERREUR: -> Ce fichier"
-    IDS_H26                 "peut être verrouillé ou espace disque distant insuffisant"
-    IDS_H27                 "envoyé avec succès..."
-    IDS_H28                 "échoué sur machine locale. Annulé"
-    IDS_H29                 "Impossible de créer le dossier"
+    IDS_H23                 "ERREUR : ProblÃ¨me d'accÃ¨s au fichier"
+    IDS_H24                 "ne peut pas Ãªtre crÃ©Ã© sur la machine distante"
+    IDS_H25                 "ERREUR : Ce fichier"
+    IDS_H26                 "est peut-Ãªtre verrouillÃ© ou l'espace disque distant est insuffisant"
+    IDS_H27                 "envoyÃ© avec succÃ¨s..."
+    IDS_H28                 "Ã©chouÃ© sur la machine locale. AnnulÃ©"
+    IDS_H29                 "Impossible de crÃ©er le dossier"
     IDS_H30                 "sur la machine distante"
     IDS_H31                 "Dossier"
-    IDS_H32                 "a été créé sur la machine distante"
+    IDS_H32                 "a Ã©tÃ© crÃ©Ã© sur la machine distante"
     IDS_H33                 "Impossible de supprimer le fichier"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_H34                 "a été supprimé sur la machine distante"
-    IDS_H35                 "Transfert fichiers avec"
-    IDS_H36                 "Connecté"
-    IDS_H37                 "Connexion. Patientez..."
-    IDS_H38                 "existe déjà sur machine distante.\n\n Voulez-vous écraser ou reprendre?\n"
-    IDS_H39                 "Avertissement transfert fichiers"
-    IDS_H40                 "Fichiers/dossiers sélectionnés pour transfert"
-    IDS_H41                 "Démarrage transfert. Envoi"
-    IDS_H42                 "Fichiers/dossiers vers machine distante"
-    IDS_H43                 "existe déjà sur machine locale.\n\n Voulez-vous écraser ou reprendre?\n"
-    IDS_H44                 "Démarrage transfert. Réception"
-    IDS_H45                 "Fichiers/dossiers depuis machine distante "
-    IDS_H46                 "Sélectionnez un fichier à supprimer.\nUn seul fichier peut être supprimé à la fois."
-    IDS_H47                 "Avertissement suppression fichier"
+    IDS_H34                 "a Ã©tÃ© supprimÃ© sur la machine distante"
+    IDS_H35                 "Transfert de fichiers avec"
+    IDS_H36                 "ConnectÃ©"
+    IDS_H37                 "Connexion en cours. Veuillez patienter..."
+    IDS_H38                 "existe dÃ©jÃ  sur la machine distante.\n\n Voulez-vous l'Ã©craser ou reprendre ?\n"
+    IDS_H39                 "Avertissement de transfert de fichiers"
+    IDS_H40                 "Fichiers/dossiers sÃ©lectionnÃ©s pour le transfert"
+    IDS_H41                 "DÃ©marrage du transfert. Envoi de"
+    IDS_H42                 "fichier(s)/dossier(s) vers la machine distante"
+    IDS_H43                 "existe dÃ©jÃ  sur la machine locale.\n\n Voulez-vous l'Ã©craser ou reprendre ?\n"
+    IDS_H44                 "DÃ©marrage du transfert. RÃ©ception de"
+    IDS_H45                 "fichier(s)/dossier(s) depuis la machine distante"
+    IDS_H46                 "SÃ©lectionnez un fichier Ã  supprimer.\nUn seul fichier peut Ãªtre supprimÃ© Ã  la fois."
+    IDS_H47                 "Avertissement de suppression de fichier"
     IDS_H48                 "Voulez-vous supprimer le fichier LOCAL"
     IDS_H49                 "Impossible de supprimer le fichier local"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_H50                 "a été supprimé"
+    IDS_H50                 "a Ã©tÃ© supprimÃ©"
     IDS_H51                 "Voulez-vous supprimer le fichier DISTANT"
-    IDS_H52                 "Entrez le nom du nouveau dossier local:"
-    IDS_H53                 "Impossible de créer le dossier local"
+    IDS_H52                 "Entrez le nom du nouveau dossier local :"
+    IDS_H53                 "Impossible de crÃ©er le dossier local"
     IDS_H54                 "Dossier local"
-    IDS_H55                 "a été créé"
-    IDS_H56                 "Entrez le nom du nouveau dossier distant:"
-    IDS_H57                 "Transfert fichiers"
-    IDS_I1                  "Erreur création socket Daemon"
-    IDS_I2                  "Erreur liaison socket Daemon"
-    IDS_I3                  "Erreur écoute Daemon"
-    IDS_J1                  "Pour quitter le plein écran, utilisez Ctrl-Esc Esc puis\r\nclic droit sur l'icône UltraVNC Viewer."
-    IDS_J2                  "UltraVNC Viewer mode plein écran"
-    IDS_K2                  "Erreur sauvegarde fichier"
+    IDS_H55                 "a Ã©tÃ© crÃ©Ã©"
+    IDS_H56                 "Entrez le nom du nouveau dossier distant :"
+    IDS_H57                 "Transfert de fichiers"
+    IDS_I1                  "Erreur Ã  la crÃ©ation du socket Daemon"
+    IDS_I2                  "Erreur Ã  la liaison du socket Daemon"
+    IDS_I3                  "Erreur Ã  l'Ã©coute du Daemon"
+    IDS_J1                  "Pour quitter le plein Ã©cran, utilisez Ctrl+Ã‰chap puis Ã‰chap,\r\npuis faites un clic droit sur l'icÃ´ne UltraVNC Viewer."
+    IDS_J2                  "UltraVNC Viewer - Mode plein Ã©cran"
+    IDS_K2                  "Erreur de sauvegarde du fichier"
     IDS_K1                  "Nom de fichier invalide"
-    IDS_K3                  "Voulez-vous sauvegarder le mot de passe?\n\r La sauvegarde du mot de passe n'est pas sécurisée."
+    IDS_K3                  "Voulez-vous sauvegarder le mot de passe ?\n\r La sauvegarde du mot de passe n'est pas sÃ©curisÃ©e."
 END
 
 STRINGTABLE
 BEGIN
-    IDS_N12                 "Mémoire insuffisante pour tampon zlib."
-    IDS_N13                 "Code de découverte invalide\n"
-    IDS_N14                 "Impossible d'utiliser l'authentification IDEA!"
-    IDS_LANGUAGE_NAME       "Français"
+    IDS_N12                 "MÃ©moire insuffisante pour le tampon zlib."
+    IDS_N13                 "Code de dÃ©couverte invalide\n"
+    IDS_N14                 "Impossible d'utiliser l'authentification IDEA !"
+    IDS_LANGUAGE_NAME       "FranÃ§ais"
     IDS_I4                  "Erreur Daemon"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_TAB_ENCODERS        "Encodeurs"
-    IDS_TAB_INPUT           "Entree"
+    IDS_TAB_ENCODERS        "Encodage"
+    IDS_TAB_INPUT           "Clavier et souris"
     IDS_TAB_DISPLAY         "Affichage"
     IDS_TAB_MISC            "Divers"
-    IDS_TAB_SECURITY        "Securite"
-    IDS_TAB_QUICKENC        "Encodeur rapide"
-    IDS_TAB_LISTEN          "Ecoute"
-    IDS_TAB_CONF            "Config"
+    IDS_TAB_SECURITY        "SÃ©curitÃ©"
+    IDS_TAB_QUICKENC        "Encodage rapide"
+    IDS_TAB_LISTEN          "Ã‰coute"
+    IDS_TAB_CONF            "Configuration"
 END
 
 STRINGTABLE
 BEGIN
     IDS_H58                 "Fichiers/dossiers"
-    IDS_H59                 "Décompression dossier"
-    IDS_H60                 "après réception. Patientez..."
+    IDS_H59                 "DÃ©compression du dossier"
+    IDS_H60                 "aprÃ¨s rÃ©ception. Veuillez patienter..."
     IDS_H61                 "Dossier distant"
-    IDS_H62                 "ERREUR décompression dossier distant"
-    IDS_H63                 "Annulé."
-    IDS_H64                 "Compression dossier local"
-    IDS_H65                 "pour transfert. Patientez..."
+    IDS_H62                 "ERREUR lors de la dÃ©compression du dossier distant"
+    IDS_H63                 "AnnulÃ©."
+    IDS_H64                 "Compression du dossier local"
+    IDS_H65                 "pour transfert. Veuillez patienter..."
     IDS_H66                 "Dossier local"
-    IDS_H67                 "compressé avec succès."
-    IDS_H68                 "ERREUR compression dossier local (fichiers protégés)"
-    IDS_H69                 "Transfert annulé."
-    IDS_H70                 "envoyé avec succès."
+    IDS_H67                 "compressÃ© avec succÃ¨s."
+    IDS_H68                 "ERREUR lors de la compression du dossier local (fichiers protÃ©gÃ©s)"
+    IDS_H69                 "Transfert annulÃ©."
+    IDS_H70                 "envoyÃ© avec succÃ¨s."
     IDS_H71                 "Le dossier DISTANT"
-    IDS_H72                 "existe déjà.\n\n Écraser avec tous ses fichiers et sous-dossiers?"
+    IDS_H72                 "existe dÃ©jÃ .\n\n Ã‰craser avec tous ses fichiers et sous-dossiers ?"
     IDS_H73                 "Le dossier LOCAL"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_K4                  "Avertissement de sécurité"
-    IDS_K5                  "Erreur lecture nom d'hôte"
-    IDS_K6                  "Erreur fichier config"
-    IDS_K7                  "Erreur lecture numéro de port"
+    IDS_K4                  "Avertissement de sÃ©curitÃ©"
+    IDS_K5                  "Erreur de lecture du nom d'hÃ´te"
+    IDS_K6                  "Erreur dans le fichier de configuration"
+    IDS_K7                  "Erreur de lecture du numÃ©ro de port"
     IDS_L1                  "inconnu"
-    IDS_L2                  "Envoyer CTRL+ALT+DEL"
-    IDS_L3                  "Basculer mode plein écran"
-    IDS_L4                  "Afficher options connexion..."
-    IDS_L5                  "Refresh Screen"
-    IDS_L6                  "Envoyer Démarrer (Ctrl+Esc)"
-    IDS_L7                  "Envoyer touche personnalisée"
-    IDS_L8                  "Afficher fenêtre statut"
-    IDS_L9                  "Fermer connexion"
-    IDS_L10                 "Masquer boutons barre d'outils"
-    IDS_L11                 "Basculer entrée distante/écran noir"
-    IDS_L12                 "Ouvrir transfert fichiers..."
+    IDS_L2                  "Envoyer Ctrl+Alt+Suppr"
+    IDS_L3                  "Basculer en plein Ã©cran"
+    IDS_L4                  "Afficher les options de connexion..."
+    IDS_L5                  "RafraÃ®chir l'Ã©cran"
+    IDS_L6                  "Envoyer DÃ©marrer (Ctrl+Ã‰chap)"
+    IDS_L7                  "Envoyer une touche personnalisÃ©e"
+    IDS_L8                  "Afficher la fenÃªtre de statut"
+    IDS_L9                  "Fermer la connexion"
+    IDS_L10                 "Masquer les boutons de la barre d'outils"
+    IDS_L11                 "Basculer l'entrÃ©e distante / Ã©cran noir"
+    IDS_L12                 "Ouvrir le transfert de fichiers..."
 END
 
 STRINGTABLE
 BEGIN
-    IDS_L13                 "Capture écran"
-    IDS_L14                 "Sélectionner bureau / Changer moniteur"
-    IDS_L15                 "Ouvrir chat..."
-    IDS_L16                 "Transfert fichiers... \tCtrl+Alt+F7"
+    IDS_L13                 "Capture d'Ã©cran"
+    IDS_L14                 "SÃ©lectionner le bureau / Changer de moniteur"
+    IDS_L15                 "Ouvrir le chat..."
+    IDS_L16                 "Transfert de fichiers... \tCtrl+Alt+F7"
     IDS_L17                 "Chat... \tCtrl+Alt+F8"
-    IDS_L18                 "Afficher barre d'outils \tCtrl+Alt+F9"
-    IDS_L19                 "Désactiver entrée/moniteur distant"
-    IDS_L20                 "Activer entrée/moniteur distant "
-    IDS_L21                 "&Options connexion... \tCtrl+Alt+F6"
-    IDS_L22                 "&Info connexion..\tCtrl+Alt+Shift+I"
-    IDS_L23                 "&Rafraîchir écran..\tCtrl+Alt+Shift+R"
-    IDS_L24                 "&Plein écran \tCtrl+Alt+F12"
-    IDS_L25                 "&Auto-échelle \tCtrl+Alt+F10"
+    IDS_L18                 "Afficher la barre d'outils \tCtrl+Alt+F9"
+    IDS_L19                 "DÃ©sactiver l'entrÃ©e / moniteur distant"
+    IDS_L20                 "Activer l'entrÃ©e / moniteur distant"
+    IDS_L21                 "&Options de connexion... \tCtrl+Alt+F6"
+    IDS_L22                 "&Infos de connexion... \tCtrl+Alt+Maj+I"
+    IDS_L23                 "&RafraÃ®chir l'Ã©cran... \tCtrl+Alt+Maj+R"
+    IDS_L24                 "&Plein Ã©cran \tCtrl+Alt+F12"
+    IDS_L25                 "&Auto-Ã©chelle \tCtrl+Alt+F10"
     IDS_L26                 "&Demi-taille \tCtrl+Alt+F11"
-    IDS_L27                 "Écran &flou"
-    IDS_L28                 "Écran &normal \tCtrl+F11"
+    IDS_L27                 "Ã‰cran &flou"
+    IDS_L28                 "Ã‰cran &normal \tCtrl+F11"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_L29                 "&Couleurs complètes"
+    IDS_L29                 "&Toutes les couleurs"
     IDS_L30                 "&256 couleurs"
-    IDS_L31                 "Envoyer Ctrl+Alt+Del \tCtrl+Alt+F4"
-    IDS_L32                 "Envoyer Ctrl+Esc (menu Démarrer)"
-    IDS_L33                 "Touche Ctrl enfoncée"
-    IDS_L34                 "Touche Ctrl relâchée"
-    IDS_L35                 "Touche Alt enfoncée"
-    IDS_L36                 "Touche Alt relâchée"
-    IDS_L37                 "&Nouvelle connexion...\tCtrl+Alt+Shift+N"
-    IDS_L38                 "Enregistrer connexion &sous... \tCtrl+Alt+F5"
-    IDS_L39                 "&About UltraVNC Viewer..."
-    IDS_L40                 "Fermer &daemon d'écoute"
+    IDS_L31                 "Envoyer Ctrl+Alt+Suppr \tCtrl+Alt+F4"
+    IDS_L32                 "Envoyer Ctrl+Ã‰chap (menu DÃ©marrer)"
+    IDS_L33                 "Touche Ctrl enfoncÃ©e"
+    IDS_L34                 "Touche Ctrl relÃ¢chÃ©e"
+    IDS_L35                 "Touche Alt enfoncÃ©e"
+    IDS_L36                 "Touche Alt relÃ¢chÃ©e"
+    IDS_L37                 "&Nouvelle connexion... \tCtrl+Alt+Maj+N"
+    IDS_L38                 "Enregistrer la connexion &sous... \tCtrl+Alt+F5"
+    IDS_L39                 "&Ã€ propos d'UltraVNC Viewer..."
+    IDS_L40                 "Fermer le &dÃ©mon d'Ã©coute"
     IDS_L41                 "DSMPlugin non configurable"
-    IDS_L42                 "Annulé par l'utilisateur"
-    IDS_L43                 "Connexion..."
-    IDS_L44                 "Erreur création socket !"
+    IDS_L42                 "AnnulÃ© par l'utilisateur"
+    IDS_L43                 "Connexion en cours..."
+    IDS_L44                 "Erreur Ã  la crÃ©ation du socket !"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_L45                 "Recherche adresse serveur..."
-    IDS_L46                 "Échec obtention adresse serveur !"
+    IDS_L45                 "Recherche de l'adresse du serveur..."
+    IDS_L46                 "Ã‰chec de l'obtention de l'adresse du serveur !"
     IDS_L47                 "Connexion au serveur..."
-    IDS_L48                 "Échec connexion au serveur !"
-    IDS_L49                 "Connecté"
-    IDS_L50                 "Erreur désactivation algorithme Nagle"
-    IDS_L51                 "Désolé - ce serveur utilise une ancienne authentification non supportée."
-    IDS_L52                 "Erreur version protocole"
+    IDS_L48                 "Ã‰chec de la connexion au serveur !"
+    IDS_L49                 "ConnectÃ©"
+    IDS_L50                 "Erreur lors de la dÃ©sactivation de l'algorithme Nagle"
+    IDS_L51                 "DÃ©solÃ© - ce serveur utilise une ancienne mÃ©thode d'authentification non supportÃ©e."
+    IDS_L52                 "Erreur de version de protocole"
     IDS_L53                 "Mot de passe vide"
-    IDS_L54                 "Authentification annulée"
-    IDS_L55                 "Mot de passe accepté"
+    IDS_L54                 "Authentification annulÃ©e"
+    IDS_L55                 "Mot de passe acceptÃ©"
     IDS_L56                 "Mot de passe incorrect"
-    IDS_L57                 "Authentification VNC échouée!"
-    IDS_L58                 "Authentification VNC échouée - trop d'essais!"
-    IDS_L59                 "Résultat authentification VNC inconnu!"
-    IDS_L60                 "Schéma authentification inconnu!"
+    IDS_L57                 "Authentification VNC Ã©chouÃ©e !"
+    IDS_L58                 "Authentification VNC Ã©chouÃ©e - trop de tentatives !"
+    IDS_L59                 "RÃ©sultat de l'authentification VNC inconnu !"
+    IDS_L60                 "SchÃ©ma d'authentification inconnu !"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_L61                 "Erreur création image locale écran."
-    IDS_L62                 "Patientez - Chargement écran initial..."
-    IDS_L63                 "Message SetColormap non géré reçu!\n"
-    IDS_L64                 "Type de message non géré reçu!\n"
-    IDS_L65                 "WriteExact: Erreur allocation DSMPlugin-RestoreBuffer."
-    IDS_L66                 "WriteExact: Erreur DSMPlugin-RestoreBuffer."
-    IDS_L67                 "Connexion fermée (1)"
-    IDS_L68                 "WriteExact: Erreur DSMPlugin-TransformBuffer."
-    IDS_L69                 "Serveur a fermé la connexion\n\r -Connexion rejetée\n\r -Déconnexion réseau\n\r -Pare-feu"
-    IDS_L70                 "Mémoire insuffisante pour tampon réseau."
-    IDS_L71                 "Mémoire insuffisante pour tampon zlib."
+    IDS_L61                 "Erreur lors de la crÃ©ation de l'image locale de l'Ã©cran."
+    IDS_L62                 "Veuillez patienter - Chargement de l'Ã©cran initial..."
+    IDS_L63                 "Message SetColormap non gÃ©rÃ© reÃ§u !\n"
+    IDS_L64                 "Type de message non gÃ©rÃ© reÃ§u !\n"
+    IDS_L65                 "WriteExact : Erreur d'allocation DSMPlugin-RestoreBuffer."
+    IDS_L66                 "WriteExact : Erreur DSMPlugin-RestoreBuffer."
+    IDS_L67                 "Connexion fermÃ©e (1)"
+    IDS_L68                 "WriteExact : Erreur DSMPlugin-TransformBuffer."
+    IDS_L69                 "Le serveur a fermÃ© la connexion\r\n - Connexion rejetÃ©e\r\n - DÃ©connexion rÃ©seau\r\n - Pare-feu"
+    IDS_L70                 "MÃ©moire insuffisante pour le tampon rÃ©seau."
+    IDS_L71                 "MÃ©moire insuffisante pour le tampon zlib."
     IDS_L72                 "Statut UltraVNC Viewer pour"
     IDS_L73                 "Statut UltraVNC Viewer"
     IDS_L74                 "Pas de connexion"
-    IDS_L75                 "Voulez-vous vraiment quitter?"
+    IDS_L75                 "Voulez-vous vraiment quitter ?"
     IDS_L76                 "Cette action fermera UltraVNC Viewer"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_L77                 "Le serveur VNC ne supporte pas le transfert fichiers!"
-    IDS_L78                 "UltraVNC Viewer - Fonctionnalité indisponible"
-    IDS_L79                 "La fenêtre transfert fichiers est déjà ouverte!"
-    IDS_L80                 "Avertissement transfert fichiers"
-    IDS_L81                 "Le serveur VNC ne supporte pas le chat texte!"
-    IDS_L82                 "UltraVNC Viewer - Fonctionnalité indisponible"
-    IDS_L83                 "La fenêtre chat est déjà ouverte!"
-    IDS_L84                 "Avertissement chat texte"
-    IDS_L85                 "Fermez d'abord la fenêtre transfert fichiers"
-    IDS_L86                 "Fermez d'abord la fenêtre chat"
-    IDS_L87                 "Fermez d'abord la fenêtre options connexion"
+    IDS_L77                 "Le serveur VNC ne supporte pas le transfert de fichiers !"
+    IDS_L78                 "UltraVNC Viewer - FonctionnalitÃ© indisponible"
+    IDS_L79                 "La fenÃªtre de transfert de fichiers est dÃ©jÃ  ouverte !"
+    IDS_L80                 "Avertissement de transfert de fichiers"
+    IDS_L81                 "Le serveur VNC ne supporte pas le chat texte !"
+    IDS_L82                 "UltraVNC Viewer - FonctionnalitÃ© indisponible"
+    IDS_L83                 "La fenÃªtre de chat est dÃ©jÃ  ouverte !"
+    IDS_L84                 "Avertissement de chat texte"
+    IDS_L85                 "Fermez d'abord la fenÃªtre de transfert de fichiers"
+    IDS_L86                 "Fermez d'abord la fenÃªtre de chat"
+    IDS_L87                 "Fermez d'abord la fenÃªtre des options de connexion"
     IDS_L88                 "UltraVNC Viewer - Avertissement"
-    IDS_L89                 "Négociation version protocole..."
-    IDS_L90                 "Mot de passe demandé"
-    IDS_L91                 "Connexion échouée"
+    IDS_L89                 "NÃ©gociation de la version du protocole..."
+    IDS_L90                 "Mot de passe demandÃ©"
+    IDS_L91                 "Connexion Ã©chouÃ©e"
     IDS_L92                 "Aucune authentification requise"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_TLS7                "EncryptMessage échoué"
-    IDS_TLS8                "DecryptMessage échoué"
-    IDS_TLS9                "Résultat DecryptMessage inattendu"
-    IDS_TLS10               "ApplyControlToken échoué"
-    IDS_TLS11               "CertGetCertificateChain échoué"
-    IDS_N1                  "Aucun élément dans la liste"
-    IDS_N2                  "Aucun serveur VNC sélectionné"
-    IDS_N3                  "Périphérique multitouch TCVNC"
-    IDS_N4                  "Fonction supportée uniquement en mode 1:1"
+    IDS_TLS7                "Ã‰chec de EncryptMessage"
+    IDS_TLS8                "Ã‰chec de DecryptMessage"
+    IDS_TLS9                "RÃ©sultat inattendu de DecryptMessage"
+    IDS_TLS10               "Ã‰chec de ApplyControlToken"
+    IDS_TLS11               "Ã‰chec de CertGetCertificateChain"
+    IDS_N1                  "Aucun Ã©lÃ©ment dans la liste"
+    IDS_N2                  "Aucun serveur VNC sÃ©lectionnÃ©"
+    IDS_N3                  "PÃ©riphÃ©rique multitouch TCVNC"
+    IDS_N4                  "Fonction supportÃ©e uniquement en mode 1:1"
     IDS_N5                  "UltraVNC Viewer - Capture"
-    IDS_N6                  "UltraVNC Viewer - Informations connexion"
+    IDS_N6                  "UltraVNC Viewer - Informations de connexion"
     IDS_N7                  "UltraVNC Viewer - Connexion perdue, reconnexion ("
     IDS_N8                  "UltraVNC Viewer - Chat avec <%s>"
     IDS_N9                  "UltraVNC Viewer -"
-    IDS_N10                 "Tous les écrans"
-    IDS_N11                 "Moniteur par défaut"
+    IDS_N10                 "Tous les Ã©crans"
+    IDS_N11                 "Moniteur par dÃ©faut"
 END
 
 #endif    // French (France) resources
@@ -1616,4 +1616,3 @@ END
 #include "version.rc2"
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
-

--- a/translations/winvnc/French/winvnc.rc
+++ b/translations/winvnc/French/winvnc.rc
@@ -49,7 +49,7 @@ FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     EDITTEXT        IDC_INPUTAREA_EDIT,4,135,255,39,ES_MULTILINE | ES_AUTOVSCROLL | ES_WANTRETURN | NOT WS_BORDER | WS_VSCROLL,WS_EX_STATICEDGE
     PUSHBUTTON      "Envoyer",IDC_SEND_B,264,135,39,16,BS_MULTILINE
-    PUSHBUTTON      "RÈduire",IDC_HIDE_B,264,152,39,11
+    PUSHBUTTON      "R√©duire",IDC_HIDE_B,264,152,39,11
     PUSHBUTTON      "Fermer",IDCANCEL,264,164,39,11
     CONTROL         "",IDC_CHATAREA_EDIT,"RICHEDIT",TCS_HOTTRACK | TCS_RAGGEDRIGHT | TCS_FOCUSONBUTTONDOWN | TCS_MULTISELECT | WS_VSCROLL | WS_TABSTOP,4,4,300,122,WS_EX_STATICEDGE
     PUSHBUTTON      "",IDOK,303,0,6,6,NOT WS_VISIBLE
@@ -63,9 +63,9 @@ FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     DEFPUSHBUTTON   "Fermer",IDOK,118,94,62,14
     PUSHBUTTON      "Annuler",IDCANCEL,118,78,62,14,NOT WS_VISIBLE
-    LTEXT           "Clients connectÈs",IDC_STATIC,5,4,105,8
+    LTEXT           "Clients connect√©s",IDC_STATIC,5,4,105,8
     LISTBOX         IDC_VIEWERS_LISTBOX,7,16,103,93,LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP,WS_EX_STATICEDGE
-    PUSHBUTTON      "DÈconnecter",IDC_KILL_B,118,17,62,14
+    PUSHBUTTON      "D√©connecter",IDC_KILL_B,118,17,62,14
     PUSHBUTTON      "Chat",IDC_TEXTCHAT_B,118,35,62,14,BS_MULTILINE
     LTEXT           "Clients en attente",IDC_STATIC,185,4,105,8
     LISTBOX         IDC_PENDING_LISTBOX,187,16,103,93,LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP,WS_EX_STATICEDGE
@@ -73,29 +73,29 @@ END
 
 IDD_ABOUT DIALOGEX 0, 0, 274, 76
 STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "UltraVNC Server - ¿ propos"
+CAPTION "UltraVNC Server - √Ä propos"
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     DEFPUSHBUTTON   "OK",IDOK,215,56,54,16
     CONTROL         IDB_LOGO64,IDC_VNCLOGO,"Static",SS_BITMAP | SS_CENTERIMAGE,7,1,39,39
     LTEXT           "UltraVNC Server 1.4.4.0-dev",IDC_VERSION,49,5,145,11
     LTEXT           "Copyright (C) 2002-2024 UltraVNC Team Members",IDC_NAME,49,27,222,12
-    LTEXT           "Website:",IDC_WWW2,15,65,31,9
-    LTEXT           "CompilÈ",IDC_BUILDTEXT,49,16,20,10
+    LTEXT           "Site web :",IDC_WWW2,15,65,31,9
+    LTEXT           "Compil√© le",IDC_BUILDTEXT,49,16,20,10
     LTEXT           "BuildTime",IDC_BUILDTIME,72,16,92,10
     LTEXT           "https://uvnc.com/",IDC_WWW,47,65,61,8
-    LTEXT           "Fichier de configuration: ",IDC_CONFIG_FILE,17,44,250,8
+    LTEXT           "Fichier de configuration : ",IDC_CONFIG_FILE,17,44,250,8
 END
 
 IDD_OUTGOING_CONN DIALOGEX 0, 0, 223, 88
 STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | DS_CENTER | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
-CAPTION "UltraVNC Server - …tablir une connexion"
+CAPTION "UltraVNC Server - √âtablir une connexion"
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     CTEXT           "",IDC_CAPTION_STATIC,7,6,209,15,NOT WS_VISIBLE
-    LTEXT           "Nom d'hÙte[:port]",IDC_HOSTNAME_STATIC,7,25,58,8,SS_CENTERIMAGE
+    LTEXT           "Nom d'h√¥te[:port]",IDC_HOSTNAME_STATIC,7,25,58,8,SS_CENTERIMAGE
     EDITTEXT        IDC_HOSTNAME_EDIT,90,22,121,14,ES_AUTOHSCROLL
-    LTEXT           "ID: (ID:1234546789)",IDC_CONNECTION_NUMBER_STATIC,7,46,74,8
+    LTEXT           "ID : (ID:1234546789)",IDC_CONNECTION_NUMBER_STATIC,7,46,74,8
     EDITTEXT        IDC_IDCODE,90,43,121,14,ES_AUTOHSCROLL
     DEFPUSHBUTTON   "OK",IDOK,90,67,46,14
     PUSHBUTTON      "Annuler",IDCANCEL,165,67,46,14
@@ -109,10 +109,10 @@ FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     PUSHBUTTON      "&Accepter",IDACCEPT,7,74,53,14
     DEFPUSHBUTTON   "&Refuser",IDREJECT,130,74,49,14
-    LTEXT           "UltraVNC Server a reÁu une connexion entrante de",IDC_STATIC_TEXT1,7,7,107,36
-    CTEXT           "<unknown host>",IDC_ACCEPT_IP,5,47,172,9,SS_CENTERIMAGE
-    CTEXT           "Voulez-vous accepter ou refuser la connexion?",IDC_STATIC_TEXT,7,58,172,15,SS_CENTERIMAGE
-    CTEXT           "AutoReject:",IDC_ACCEPT_TIMEOUT,60,74,70,14,SS_CENTERIMAGE
+    LTEXT           "UltraVNC Server a re√ßu une connexion entrante de",IDC_STATIC_TEXT1,7,7,107,36
+    CTEXT           "<h√¥te inconnu>",IDC_ACCEPT_IP,5,47,172,9,SS_CENTERIMAGE
+    CTEXT           "Voulez-vous accepter ou refuser la connexion ?",IDC_STATIC_TEXT,7,58,172,15,SS_CENTERIMAGE
+    CTEXT           "Rejet automatique :",IDC_ACCEPT_TIMEOUT,60,74,70,14,SS_CENTERIMAGE
     CONTROL         IDB_LOGO64,IDC_ACCEPTLOGO,"Static",SS_BITMAP,130,7,43,39
 END
 
@@ -122,11 +122,11 @@ CAPTION "UltraVNC Server - Connexion Cloud"
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     DEFPUSHBUTTON   "Enregistrer",IDOK,253,82,50,14
-    CONTROL         "DÈmarrage auto",IDC_CHECKCLOUD,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,18,15,48,10
+    CONTROL         "D√©marrage auto",IDC_CHECKCLOUD,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,18,15,48,10
     EDITTEXT        IDC_CLOUDSERVER,97,38,93,14,ES_AUTOHSCROLL
     LTEXT           "Code de connexion Cloud",IDC_STATIC,18,60,67,8
     LTEXT           "",IDC_CLOUDCODE,97,59,94,15
-    PUSHBUTTON      "DÈmarrer",IDC_STARTCLOUD,97,15,53,12
+    PUSHBUTTON      "D√©marrer",IDC_STARTCLOUD,97,15,53,12
     LTEXT           "Serveur Cloud",IDC_STATIC,18,40,72,8
     LTEXT           "Adresse IP externe",IDC_STATIC,18,83,66,8
     LTEXT           "",IDC_EXTERNALIPADDRESS,97,83,97,8
@@ -173,11 +173,11 @@ BEGIN
     EDITTEXT        IDC_GROUP3,21,53,93,13,ES_AUTOHSCROLL
     CONTROL         "",IDC_CHECKG3L,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,127,56,16,8
     CONTROL         "",IDC_CHECKG3D,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,153,56,16,8
-    GROUPBOX        "RËgles",IDC_STATIC,5,77,178,68
-    LTEXT           "Groupe 1, 2 = AccËs complet   Groupe 3 = Lecture seule",IDC_STATIC,16,88,162,8
-    LTEXT           "Les administrateurs locaux ont toujours accËs.",IDC_STATIC,8,100,174,41
+    GROUPBOX        "R√®gles",IDC_STATIC,5,77,178,68
+    LTEXT           "Groupes 1 et 2 = Acc√®s complet   Groupe 3 = Affichage seul",IDC_STATIC,16,88,162,8
+    LTEXT           "Les administrateurs locaux ont toujours acc√®s.",IDC_STATIC,8,100,174,41
     DEFPUSHBUTTON   "OK",IDOK,77,148,50,14
-    PUSHBUTTON      "ANNULER",IDCANCEL,132,148,50,14
+    PUSHBUTTON      "Annuler",IDCANCEL,132,148,50,14
     LTEXT           "1",IDC_STATIC,11,22,8,8
     LTEXT           "2",IDC_STATIC,11,38,8,8
     LTEXT           "3",IDC_STATIC,11,56,8,8
@@ -316,12 +316,12 @@ IDR_TRAYMENU MENU
 BEGIN
     POPUP "tray"
     BEGIN
-        MENUITEM "&ParamËtres",                   ID_ADMIN_PROPERTIES
+        MENUITEM "&Param√®tres",                       ID_ADMIN_PROPERTIES
         MENUITEM SEPARATOR
-        MENUITEM "&¿ propos de UltraVNC Server...",   ID_ABOUT
+        MENUITEM "&√Ä propos d'UltraVNC Server...",    ID_ABOUT
         POPUP "Visiter nos liens"
         BEGIN
-            MENUITEM "Homepage",                    ID_VISITUSONLINE_HOMEPAGE
+            MENUITEM "Page d'accueil",              ID_VISITUSONLINE_HOMEPAGE
             MENUITEM "Forum",                       ID_VISITUSONLINE_FORUM
             MENUITEM "GitHub",                      ID_VISITUSONLINE_GITHUB
             MENUITEM "Mastodon",                    ID_VISITUSONLINE_MASTODON
@@ -332,19 +332,19 @@ BEGIN
             MENUITEM "OpenHub",                     ID_VISITUSONLINE_OPENHUB
         END
         MENUITEM SEPARATOR
-        MENUITEM "Ajouter un nouveau client",             ID_OUTGOING_CONN
-        MENUITEM "&DÈconnecter tous les clients",           ID_KILLCLIENTS
+        MENUITEM "Ajouter un nouveau client",              ID_OUTGOING_CONN
+        MENUITEM "&D√©connecter tous les clients",          ID_KILLCLIENTS
         MENUITEM SEPARATOR
-        MENUITEM "&Lister tous les clients",           ID_LISTCLIENTS
+        MENUITEM "&Lister tous les clients",               ID_LISTCLIENTS
         MENUITEM SEPARATOR
-        MENUITEM "Installer le service",             ID_RUNASSERVICE
-        MENUITEM "DÈsinstaller le service",           ID_UNINSTALL_SERVICE
-        MENUITEM "ArrÍter le service",                ID_CLOSE_SERVICE
-        MENUITEM "DÈmarrer le service (doit Ítre installÈ)", ID_START_SERVICE
-        MENUITEM "RedÈmarrer en mode sans Èchec",         ID_REBOOTSAFEMODE
-        MENUITEM "Forcer le redÈmarrage (dangereux)",       ID_REBOOT_FORCE
+        MENUITEM "Installer le service",                   ID_RUNASSERVICE
+        MENUITEM "D√©sinstaller le service",                ID_UNINSTALL_SERVICE
+        MENUITEM "Arr√™ter le service",                     ID_CLOSE_SERVICE
+        MENUITEM "D√©marrer le service (doit √™tre install√©)", ID_START_SERVICE
+        MENUITEM "Red√©marrer en mode sans √©chec",          ID_REBOOTSAFEMODE
+        MENUITEM "Forcer le red√©marrage (dangereux)",      ID_REBOOT_FORCE
         MENUITEM SEPARATOR
-        MENUITEM "&Fermer connexions VNC",      ID_CLOSE
+        MENUITEM "&Fermer les connexions VNC",             ID_CLOSE
     END
 END
 
@@ -352,9 +352,9 @@ IDR_TRAYMENU1 MENU
 BEGIN
     POPUP "tray"
     BEGIN
-        MENUITEM "&¿ propos de UltraVNC Server...",   ID_ABOUT
+        MENUITEM "&√Ä propos d'UltraVNC Server...",    ID_ABOUT
         MENUITEM SEPARATOR
-        MENUITEM "&Fermer connexions VNC",      ID_CLOSE
+        MENUITEM "&Fermer les connexions VNC",         ID_CLOSE
     END
 END
 
@@ -479,51 +479,51 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_WARNING             "WARNING: By default, this session do not use any encryption whatsoever. Please do not use it to send sensitive data unless you are sure your connection is secure.\n\n"
+    IDS_WARNING             "AVERTISSEMENT : Par d√©faut, cette session n'utilise aucun chiffrement. Ne l'utilisez pas pour transmettre des donn√©es sensibles, sauf si vous √™tes certain que votre connexion est s√©curis√©e.\n\n"
 END
 
 STRINGTABLE
 BEGIN
-    ID_CURRENT_USER_PROP    "UltraVNC Server: PropriÈtÈs de l'utilisateur actuel"
-    ID_DEFAULT_SYST_PROP    "UltraVNC Server: PropriÈtÈs systËme par dÈfaut"
+    ID_CURRENT_USER_PROP    "UltraVNC Server : Propri√©t√©s de l'utilisateur actuel"
+    ID_DEFAULT_SYST_PROP    "UltraVNC Server : Propri√©t√©s syst√®me par d√©faut"
     ID_DESKTOP_BITBLT_MEM   "vncDesktop: Memory device doesn't support GetDIBits\nUltraVNC Server cannot be used with this graphics device driver"
     ID_DESKTOP_BITBLT_ROOT  "vncDesktop: Root device doesn't support BitBlt\nUltraVNC Server cannot be used with this graphics device driver"
     ID_DESKTOP_PLANAR_NOTC  "vncDesktop: Current display is PLANAR, not CHUNKY!\nUltraVNC Server cannot be used with this graphics device driver"
-    ID_FAILED_CONNECT_LISTING_VIEW "…chec de connexion au VNC Viewer en Ècoute"
-    ID_FAILED_INIT          "…chec d'initialisation du systËme socket"
+    ID_FAILED_CONNECT_LISTING_VIEW "√âchec de connexion au client VNC en √©coute"
+    ID_FAILED_INIT          "√âchec d'initialisation du syst√®me socket"
     ID_MB1                  "MB1"
-    ID_NO_CURRENT_USER_ERR  "Les paramËtres UltraVNC Server pour l'utilisateur actuel sont actuellement indisponibles."
-    ID_NO_EXIST_INST        "Aucune instance existante de UltraVNC Server n'a pu Ítre contactÈe"
+    ID_NO_CURRENT_USER_ERR  "Les param√®tres UltraVNC Server pour l'utilisateur actuel sont actuellement indisponibles."
+    ID_NO_EXIST_INST        "Aucune instance existante d'UltraVNC Server n'a pu √™tre contact√©e"
 END
 
 STRINGTABLE
 BEGIN
     ID_WARNING              "AVERTISSEMENT"
     ID_WINVNC_ERROR         "UltraVNC Server - Erreur"
-    ID_WINVNC_USAGE         "UltraVNC Server Usage"
+    ID_WINVNC_USAGE         "Utilisation d'UltraVNC Server"
     ID_WINVNC_WARNIN        "UltraVNC Server - Avertissement"
     ID_WVNC                 "WVNC"
 END
 
 STRINGTABLE
 BEGIN
-    ID_ANOTHER_INST         "Une autre instance de UltraVNC Server est dÈj‡ en cours d'exÈcution"
-    ID_AUTHAD_NOT_FO        "Vous avez sÈlectionnÈ MS-Logon, mais authad.dll\nn'a pas ÈtÈ trouvÈ. VÈrifiez votre installation"
-    ID_AUTH_NOT_FO          "Vous avez sÈlectionnÈ MS-Logon, mais auth.dll\nn'a pas ÈtÈ trouvÈ. VÈrifiez votre installation"
-    ID_AUTOACCEPT_U         "Acceptation auto: %u"
-    ID_AUTOREJECT_U         "Rejet auto: %u"
-    ID_CADERROR             "Ctrl-Alt-Suppr nÈcessite le service, pas de permission"
-    ID_CADERRORFILE         "Le fichier cad.exe n'a pas ÈtÈ trouvÈ dans le mÍme dossier que winvnc.exe"
+    ID_ANOTHER_INST         "Une autre instance d'UltraVNC Server est d√©j√† en cours d'ex√©cution"
+    ID_AUTHAD_NOT_FO        "Vous avez s√©lectionn√© MS-Logon, mais authad.dll\nn'a pas √©t√© trouv√©. V√©rifiez votre installation"
+    ID_AUTH_NOT_FO          "Vous avez s√©lectionn√© MS-Logon, mais auth.dll\nn'a pas √©t√© trouv√©. V√©rifiez votre installation"
+    ID_AUTOACCEPT_U         "Acceptation automatique : %u"
+    ID_AUTOREJECT_U         "Rejet automatique : %u"
+    ID_CADERROR             "Ctrl+Alt+Suppr n√©cessite le service ‚Äî permission insuffisante"
+    ID_CADERRORFILE         "Le fichier cad.exe n'a pas √©t√© trouv√© dans le m√™me dossier que winvnc.exe"
     ID_CADPERMISSION        "Permission denied on cad.exe, UltraVNC must be installed in ""program files"" else special cad permission is refused."
-    ID_CANNOT_EDIT_DEFAULT_PREFS 
-                            "You do not have sufficient privileges to edit the default local UltraVNC Server settings."
-    ID_CHAT_WITH_S_ULTRAVNC "UltraVNC Server - Chat with <%s>"
+    ID_CANNOT_EDIT_DEFAULT_PREFS
+                            "Vous ne disposez pas des privil√®ges suffisants pour modifier les param√®tres locaux par d√©faut d'UltraVNC Server."
+    ID_CHAT_WITH_S_ULTRAVNC "UltraVNC Server - Chat avec <%s>"
 END
 
 STRINGTABLE
 BEGIN
-    ID_SERV_SUCCESS_UNREG   "Le service UltraVNC Server a ÈtÈ dÈsinscrit"
-    ID_ULTRAVNC_TEXTCHAT    "The selected client is not an UltraVNC Viewer!\nIt presumably does not support Text Chat\n"
+    ID_SERV_SUCCESS_UNREG   "Le service UltraVNC Server a √©t√© d√©sinscrit"
+    ID_ULTRAVNC_TEXTCHAT    "Le client s√©lectionn√© n'est pas un client UltraVNC !\nIl ne supporte probablement pas le chat texte.\n"
     ID_ULTRAVNC_WARNING     "Avertissement UltraVNC"
     ID_UNABLE_INST          "Impossible d'installer le service UltraVNC Server"
     ID_UNABLE_PROC_MSLOGON  "Impossible de traiter MS-Logon"
@@ -532,85 +532,85 @@ END
 STRINGTABLE
 BEGIN
     ID_SCM_NOT_HERE         "The SCM could not be contacted - the UltraVNC Server service was not installed"
-    ID_SERVHELP_NREM        "AVERTISSEMENT: L'entrÈe ServiceHelper n'a pas pu Ítre supprimÈe du registre"
-    ID_SERVHELP_UNAB        "AVERTISSEMENT: Impossible d'installer le hook ServiceHelper\nLes paramËtres de registre utilisateur ne seront pas chargÈs"
+    ID_SERVHELP_NREM        "AVERTISSEMENT : L'entr√©e ServiceHelper n'a pas pu √™tre supprim√©e du registre"
+    ID_SERVHELP_UNAB        "AVERTISSEMENT : Impossible d'installer le hook ServiceHelper\nLes param√®tres de registre utilisateur ne seront pas charg√©s"
     ID_SERV_CT_MISS         "The Service Control Manager could not be contacted - the UltraVNC Server service was not registered"
     ID_SERV_CT_UNREG        "The Service Control Manager could not be contacted - the UltraVNC Server service was not unregistered"
-    ID_SERV_FAIL_ST         "Le service UltraVNC Server n'a pas pu dÈmarrer"
-    ID_SERV_MK_UNREG        "Le service UltraVNC Server est dÈj‡ marquÈ pour dÈsinscription"
-    ID_SERV_NCONTACT        "Le service UltraVNC Server n'a pas pu Ítre contactÈ"
-    ID_SERV_NOT_REG         "Le service UltraVNC Server n'a pas pu Ítre enregistrÈ"
-    ID_SERV_NOT_STOP        "Le service UltraVNC Server n'a pas pu Ítre arrÍtÈ"
-    ID_SERV_NOT_UNRG        "Le service UltraVNC Server n'a pas pu Ítre dÈsinscrit"
-    ID_SERV_NT_FOUND        "Le service UltraVNC Server n'a pas ÈtÈ trouvÈ"
-    ID_SERV_OLD_REG         "Le service UltraVNC Server est dÈj‡ enregistrÈ"
-    ID_SERV_SUCCESS_INST    "The UltraVNC Server service was successfully installed\nThe service will start now and will automatically\nbe run the next time this machine is rebooted"
-    ID_SERV_SUCCESS_REG     "The UltraVNC Server service was successfully registered\nThe service may be started from the Control Panel, and will\nautomatically be run the next time this machine is rebooted"
+    ID_SERV_FAIL_ST         "Le service UltraVNC Server n'a pas pu d√©marrer"
+    ID_SERV_MK_UNREG        "Le service UltraVNC Server est d√©j√† marqu√© pour d√©sinscription"
+    ID_SERV_NCONTACT        "Le service UltraVNC Server n'a pas pu √™tre contact√©"
+    ID_SERV_NOT_REG         "Le service UltraVNC Server n'a pas pu √™tre enregistr√©"
+    ID_SERV_NOT_STOP        "Le service UltraVNC Server n'a pas pu √™tre arr√™t√©"
+    ID_SERV_NOT_UNRG        "Le service UltraVNC Server n'a pas pu √™tre d√©sinscrit"
+    ID_SERV_NT_FOUND        "Le service UltraVNC Server n'a pas √©t√© trouv√©"
+    ID_SERV_OLD_REG         "Le service UltraVNC Server est d√©j√† enregistr√©"
+    ID_SERV_SUCCESS_INST    "Le service UltraVNC Server a √©t√© install√© avec succ√®s.\nIl va d√©marrer maintenant et sera lanc√© automatiquement\nau prochain red√©marrage de cette machine."
+    ID_SERV_SUCCESS_REG     "Le service UltraVNC Server a √©t√© enregistr√© avec succ√®s.\nIl peut √™tre d√©marr√© depuis le Panneau de configuration et sera\nlanc√© automatiquement au prochain red√©marrage de cette machine."
 END
 
 STRINGTABLE
 BEGIN
-    ID_NO_OVERRIDE_ERR      "This machine has been preconfigured with UltraVNC Server settings, which cannot be overridden by individual users. The preconfigured settings may be modified only by a System Administrator."
-    ID_NO_PASSWD_NO_LOGON_WARN 
-                            "WARNING: This machine has no default password set. UltraVNC Server will present the Default Properties dialog now to allow one to be entered."
-    ID_NO_PASSWD_NO_OVERRIDE_ERR 
-                            "No password has been set & this machine has been preconfigured to prevent users from setting their own.\nYou must contact a System Administrator to configure UltraVNC Server properly."
-    ID_NO_PASSWD_NO_OVERRIDE_WARN 
-                            "WARNING: This machine has been preconfigured to allow unauthenticated\nconnections to be accepted and to prevent users from enabling authentication."
-    ID_NO_PASSWORD_WARN     "WARNING: Running UltraVNC Server without setting a password is a dangerous security risk!\nUntil you set a password, UltraVNC Server will not accept incoming connections."
-    ID_NO_PLUGIN_DETECT     "Aucun plugin dÈtectÈ..."
+    ID_NO_OVERRIDE_ERR      "Cette machine a √©t√© pr√©configur√©e avec des param√®tres UltraVNC Server qui ne peuvent pas √™tre modifi√©s par les utilisateurs. Seul un administrateur syst√®me peut modifier ces param√®tres."
+    ID_NO_PASSWD_NO_LOGON_WARN
+                            "AVERTISSEMENT : Aucun mot de passe par d√©faut n'est d√©fini sur cette machine. UltraVNC Server va afficher la bo√Æte de dialogue des propri√©t√©s par d√©faut pour vous permettre d'en saisir un."
+    ID_NO_PASSWD_NO_OVERRIDE_ERR
+                            "Aucun mot de passe n'a √©t√© d√©fini et cette machine a √©t√© pr√©configur√©e pour emp√™cher les utilisateurs d'en d√©finir un.\nVeuillez contacter un administrateur syst√®me pour configurer UltraVNC Server correctement."
+    ID_NO_PASSWD_NO_OVERRIDE_WARN
+                            "AVERTISSEMENT : Cette machine a √©t√© pr√©configur√©e pour accepter les connexions sans authentification et emp√™cher les utilisateurs d'activer l'authentification."
+    ID_NO_PASSWORD_WARN     "AVERTISSEMENT : Faire fonctionner UltraVNC Server sans mot de passe repr√©sente un risque de s√©curit√© grave !\nTant qu'aucun mot de passe n'est d√©fini, UltraVNC Server n'acceptera pas de connexions entrantes."
+    ID_NO_PLUGIN_DETECT     "Aucun plugin d√©tect√©..."
     ID_OUTGOING_CONNECTION  "Connexion sortante"
     ID_PLUGIN_LOADIN        "Chargement du plugin"
-    ID_PLUGIN_NOT_LOAD      "Le plugin ne peut pas Ítre chargÈ.\n\rVeuillez vÈrifier son intÈgritÈ."
+    ID_PLUGIN_NOT_LOAD      "Le plugin ne peut pas √™tre charg√©.\n\rVeuillez v√©rifier son int√©grit√©."
     ID_RICHED32_DLL_LD      "Chargement de la DLL Rich Edit"
-    ID_RICHED32_UNLOAD      "Impossible de charger le contrÙle Rich Edit (RICHED32.DLL)!"
+    ID_RICHED32_UNLOAD      "Impossible de charger le contr√¥le Rich Edit (RICHED32.DLL) !"
 END
 
 STRINGTABLE 
 BEGIN 
-    IDS_WINDOWS_XP_SPECIAL_BUILD    "Windows XP nÈcessite une version spÈciale" 
+    IDS_WINDOWS_XP_SPECIAL_BUILD    "Windows XP n√©cessite une version sp√©ciale" 
     IDS_WARNING_CAPTION             "Avertissement" 
-    IDS_ERROR_OS_NOT_SUPPORTED      "Erreur: SystËme d'exploitation non supportÈ" 
-    IDS_UNSUPPORTED_OS_CAPTION      "SystËme non supportÈ" 
+    IDS_ERROR_OS_NOT_SUPPORTED      "Erreur : Syst√®me d'exploitation non support√©" 
+    IDS_UNSUPPORTED_OS_CAPTION      "Syst√®me non support√©" 
     IDS_AUTHADMIN_DLL_NOT_FOUND     "authadmin.dll introuvable" 
     IDS_WORKGRPDOMNT4_DLL_NOT_FOUND "workgrpdomnt4.dll introuvable" 
     IDS_LDAPAUTH_DLL_NOT_FOUND      "ldapauth.dll introuvable" 
     IDS_LDAPAUTHNT4_DLL_NOT_FOUND   "ldapauthnt4.dll introuvable" 
     IDS_LDAPAUTH9X_DLL_NOT_FOUND    "ldapauth9x.dll introuvable" 
-    IDS_KILL_VIEWERS_QUESTION       "Voulez-vous dÈconnecter tous les Viewers connectÈs?" 
-    IDS_RESTART_SERVER_QUESTION     "Voulez-vous redÈmarrer le UltraVNC Server?" 
-    IDS_CLOSE_SERVER_QUESTION       "Voulez-vous fermer le UltraVNC Server?" 
-    IDS_REBOOT_SYSTEM_QUESTION      "Voulez-vous redÈmarrer le systËme?" 
-    IDS_FORCE_REBOOT_QUESTION       "Voulez-vous forcer le redÈmarrage du systËme?" 
-    IDS_UNINSTALL_SERVICE_QUESTION  "Voulez-vous dÈsinstaller le service UltraVNC?" 
-    IDS_INSTALL_SERVICE_QUESTION    "Voulez-vous installer UltraVNC en tant que service?" 
-    IDS_STOP_SERVICE_QUESTION       "Voulez-vous arrÍter le service UltraVNC?" 
-    IDS_START_SERVICE_QUESTION      "Voulez-vous dÈmarrer le service UltraVNC?" 
-    IDS_SYSTEM_CAPTION               "SystËme" 
-    IDS_SERVICE_CAPTION              "Service" 
-    IDS_CURRENT_DRIVER_OLD          "Le pilote actuel est trop ancien pour cette version\nMettez ‡ jour le pilote ou dÈsactivez le pilote Video hook\n dans les paramËtres du serveur" 
-    IDS_DRIVER_NOT_FOUND_REBOOT     "Pilote introuvable: Un redÈmarrage aprËs installation est peut-Ítre nÈcessaire" 
-    IDS_DRIVER_INFO_REQUIRED_VERSION "Info pilote: Version requise 1.00.22" 
-    IDS_FAILED_OPEN_SVC_MGR         "…chec d'ouverture du gestionnaire de services" 
-    IDS_FAILED_PERMISSION_DENIED    "…chec: Permission refusÈe" 
-    IDS_FAILED_CREATE_SVC           "…chec de crÈation du service" 
-    IDS_FAILED_SVC_NOT_INSTALLED    "…chec: Le service n'est pas installÈ" 
-    IDS_FAILED_OPEN_SVC             "…chec d'ouverture du service" 
-    IDS_FAILED_QUERY_SVC_STATUS     "…chec de requÍte du statut du service" 
-    IDS_FAILED_DELETE_SVC           "…chec de suppression du service" 
-    IDS_WRONG_PASSWORD_RETRY        "Mot de passe incorrect, voulez-vous rÈessayer?" 
-    IDS_ERROR_CAPTION                "Erreur" 
-    IDS_UAC_DISABLED_REGISTRY        "UAC dÈsactivÈ, modifiez le registre pour autoriser CAD" 
-    IDS_VERIFY_SAME_FOLDER           "VÈrifiez que winvnc.exe et uvnc_settings sont dans le mÍme dossier\n impossible de crÈer uvnc_service"
-    IDS_DRIVER_FOUND                 "Pilote trouvÈ. " 
-    IDS_DRIVER_VERSION_OK            "Version du pilote OK " 
-    IDS_DRIVER_VERSION_NOT_OK        "La version du pilote n'est pas 1.00.22 " 
-    IDS_DRIVER_NOT_ACTIVATED         "Pilote non activÈ, le viewer est-il connectÈ?" 
-    IDS_DRIVER_ONLY_SERVICE_ADMIN    "Un pilote Mirror ne peut Ítre dÈmarrÈ que si UltraVNC Server est un service ou exÈcutÈ en admin" 
-    IDS_DRIVER_ACTIVE                " pilote actif" 
-    IDS_DRIVER_ACCESS_OK             " accËs OK" 
-    IDS_DRIVER_ACCESS_DENIED         " accËs refusÈ, problËme de permission"
-    IDS_LANGUAGE_NAME                "FranÁais"
+    IDS_KILL_VIEWERS_QUESTION       "Voulez-vous d√©connecter tous les clients connect√©s ?" 
+    IDS_RESTART_SERVER_QUESTION     "Voulez-vous red√©marrer UltraVNC Server ?" 
+    IDS_CLOSE_SERVER_QUESTION       "Voulez-vous fermer UltraVNC Server ?" 
+    IDS_REBOOT_SYSTEM_QUESTION      "Voulez-vous red√©marrer le syst√®me ?" 
+    IDS_FORCE_REBOOT_QUESTION       "Voulez-vous forcer le red√©marrage du syst√®me ?" 
+    IDS_UNINSTALL_SERVICE_QUESTION  "Voulez-vous d√©sinstaller le service UltraVNC ?" 
+    IDS_INSTALL_SERVICE_QUESTION    "Voulez-vous installer UltraVNC en tant que service ?" 
+    IDS_STOP_SERVICE_QUESTION       "Voulez-vous arr√™ter le service UltraVNC ?" 
+    IDS_START_SERVICE_QUESTION      "Voulez-vous d√©marrer le service UltraVNC ?" 
+    IDS_SYSTEM_CAPTION              "Syst√®me" 
+    IDS_SERVICE_CAPTION             "Service" 
+    IDS_CURRENT_DRIVER_OLD          "Le pilote actuel est trop ancien pour cette version.\nMettez √† jour le pilote ou d√©sactivez le pilote Video Hook\ndans les param√®tres du serveur." 
+    IDS_DRIVER_NOT_FOUND_REBOOT     "Pilote introuvable : un red√©marrage apr√®s installation est peut-√™tre n√©cessaire" 
+    IDS_DRIVER_INFO_REQUIRED_VERSION "Info pilote : version requise 1.00.22" 
+    IDS_FAILED_OPEN_SVC_MGR         "√âchec d'ouverture du gestionnaire de services" 
+    IDS_FAILED_PERMISSION_DENIED    "√âchec : permission refus√©e" 
+    IDS_FAILED_CREATE_SVC           "√âchec de cr√©ation du service" 
+    IDS_FAILED_SVC_NOT_INSTALLED    "√âchec : le service n'est pas install√©" 
+    IDS_FAILED_OPEN_SVC             "√âchec d'ouverture du service" 
+    IDS_FAILED_QUERY_SVC_STATUS     "√âchec de la requ√™te du statut du service" 
+    IDS_FAILED_DELETE_SVC           "√âchec de suppression du service" 
+    IDS_WRONG_PASSWORD_RETRY        "Mot de passe incorrect, voulez-vous r√©essayer ?" 
+    IDS_ERROR_CAPTION               "Erreur" 
+    IDS_UAC_DISABLED_REGISTRY       "UAC d√©sactiv√© ‚Äî modifiez le registre pour autoriser CAD" 
+    IDS_VERIFY_SAME_FOLDER          "V√©rifiez que winvnc.exe et uvnc_settings se trouvent dans le m√™me dossier.\nImpossible de cr√©er uvnc_service."
+    IDS_DRIVER_FOUND                "Pilote trouv√©." 
+    IDS_DRIVER_VERSION_OK           "Version du pilote OK." 
+    IDS_DRIVER_VERSION_NOT_OK       "La version du pilote n'est pas 1.00.22." 
+    IDS_DRIVER_NOT_ACTIVATED        "Pilote non activ√© ‚Äî un client est-il connect√© ?" 
+    IDS_DRIVER_ONLY_SERVICE_ADMIN   "Un pilote Mirror ne peut √™tre d√©marr√© que si UltraVNC Server fonctionne en tant que service ou est ex√©cut√© en administrateur" 
+    IDS_DRIVER_ACTIVE               " pilote actif" 
+    IDS_DRIVER_ACCESS_OK            " acc√®s OK" 
+    IDS_DRIVER_ACCESS_DENIED        " acc√®s refus√© ‚Äî probl√®me de permission"
+    IDS_LANGUAGE_NAME               "Fran√ßais"
 END 
 
 #endif    // French resources
@@ -630,7 +630,7 @@ LANGUAGE LANG_FRENCH, SUBLANG_FRENCH
 
 IDD_PROPERTIESDIALOG DIALOGEX 0, 0, 380, 253
 STYLE DS_SETFONT | DS_MODALFRAME | DS_SETFOREGROUND | DS_FIXEDSYS | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "UltraVNC Server - ParamËtres"
+CAPTION "UltraVNC Server - Param√®tres"
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     DEFPUSHBUTTON   "OK",IDOK,204,232,50,14
@@ -644,7 +644,7 @@ STYLE DS_SETFONT | DS_FIXEDSYS | WS_CHILD
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     LTEXT           "Mot de passe VNC",IDC_PASSWORD_LABEL,11,17,50,11,SS_CENTERIMAGE
-    LTEXT           "Mot de passe lecture seule",IDC_PASSWORD_LABEL2,11,38,69,11,SS_CENTERIMAGE
+    LTEXT           "Mot de passe affichage seul",IDC_PASSWORD_LABEL2,11,38,69,11,SS_CENTERIMAGE
     CONTROL         "Mot de passe non portable",IDC_SAVEPASSWORDSECURE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,57,189,10
     GROUPBOX        "Authentification",IDC_STATIC,7,4,344,76
     CONTROL         "MS-Logon",IDC_MSLOGON_CHECKD,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,95,67,10
@@ -657,11 +657,11 @@ BEGIN
     GROUPBOX        "Chiffrement",IDC_STATIC,7,129,344,33
     CONTROL         "Mot de passe requis",IDC_AUTHREQUIRED,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,11,175,68,9
     LTEXT           "Compte administrateur requis",IDC_STATIC,200,90,77,8
-    LTEXT           "DISABLING THE PASSWORD IS \nNOT RECOMMENDED",IDC_STATIC,87,172,115,19
-    LTEXT           "Le mot de passe chiffrÈ ne peut Ítre dÈchiffrÈ que sur ce systËme",IDC_STATIC,20,67,251,8
-    PUSHBUTTON      "D…FINIR/MODIFIER...",IDC_CHANGEPASSWORD,83,15,64,14
+    LTEXT           "D√âSACTIVER LE MOT DE PASSE EST\nD√âCONSEILL√â",IDC_STATIC,87,172,115,19
+    LTEXT           "Le mot de passe chiffr√© ne peut √™tre d√©chiffr√© que sur ce syst√®me",IDC_STATIC,20,67,251,8
+    PUSHBUTTON      "D√âFINIR/MODIFIER...",IDC_CHANGEPASSWORD,83,15,64,14
     PUSHBUTTON      "Effacer",IDC_CLEARPASSWORD,161,15,50,14
-    PUSHBUTTON      "D…FINIR/MODIFIER...",IDC_CHANGEPASSWORDVO,83,37,64,14
+    PUSHBUTTON      "D√âFINIR/MODIFIER...",IDC_CHANGEPASSWORDVO,83,37,64,14
     PUSHBUTTON      "Effacer",IDC_CLEARPASSWORDVO,161,37,50,14
 END
 
@@ -669,15 +669,15 @@ IDD_FORM_Network DIALOGEX 0, 0, 361, 207
 STYLE DS_SETFONT | DS_FIXEDSYS | WS_CHILD
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
-    LTEXT           "Se connecter ‡ un viewer en Ècoute",IDC_STATIC,13,19,103,8
-    PUSHBUTTON      "DÈmarrer",IDC_STARTREP,285,18,36,12
+    LTEXT           "Se connecter √† un client en √©coute",IDC_STATIC,13,19,103,8
+    PUSHBUTTON      "D√©marrer",IDC_STARTREP,285,18,36,12
     LTEXT           "Le service initie une connexion inverse",IDC_STATIC,13,32,134,8
     EDITTEXT        IDC_SERVICE_COMMANDLINE,13,43,308,14,ES_AUTOHSCROLL
     LTEXT           "-autoreconnect ID:1234 -connect [ip repeater]",IDC_STATIC,13,59,157,8
-    CONTROL         "Authentification requise pour les connexions initiÈes par le serveur",IDC_REVERSEAUTH,
+    CONTROL         "Authentification requise pour les connexions initi√©es par le serveur",IDC_REVERSEAUTH,
                     "Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_TABSTOP,13,74,266,16
     GROUPBOX        "Connexion inverse",IDC_STATIC,7,7,344,88
-    CONTROL         "Autoriser connexions Bridge (dÈconnexion 5s)",IDC_CHECKBRIDGE,
+    CONTROL         "Autoriser les connexions Bridge (d√©connexion apr√®s 5s)",IDC_CHECKBRIDGE,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,115,161,10
     GROUPBOX        "Bridge",IDC_STATIC,7,101,314,29
 END
@@ -686,8 +686,8 @@ IDD_FORM_Log DIALOGEX 0, 0, 361, 211
 STYLE DS_SETFONT | DS_FIXEDSYS | WS_CHILD
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
-    CONTROL         "Enregistrer infos debug dans WinVNC.log",IDC_LOG,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,18,139,10
-    CONTROL         "Enregistrer en vidÈo",IDC_VIDEO,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,46,58,10
+    CONTROL         "Enregistrer les infos de d√©bogage dans WinVNC.log",IDC_LOG,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,18,139,10
+    CONTROL         "Enregistrer en vid√©o",IDC_VIDEO,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,46,58,10
     PUSHBUTTON      "EFFACER ENCODEUR AVI",IDC_CLEAR,79,47,75,9
     LTEXT           "Chemin",IDC_STATIC,13,33,18,8
     EDITTEXT        IDC_EDIT_PATH,37,30,286,14,ES_AUTOHSCROLL
@@ -702,10 +702,10 @@ FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     GROUPBOX        "Administration",IDC_STATIC,7,7,324,195,BS_LEFT
     LTEXT           "Mot de passe administration",IDC_STATIC,12,44,78,8
-    CONTROL         "Autoriser les utilisateurs ‡ voir et modifier les paramËtres avec ce mot de passe",IDC_ALLOWUSERSSETTINGS,
+    CONTROL         "Autoriser les utilisateurs √† voir et modifier les param√®tres avec ce mot de passe",IDC_ALLOWUSERSSETTINGS,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,12,63,232,10
-    LTEXT           "As admin you can set a password to allow non administrators to view and change the settings.",IDC_STATIC_ADMIN,12,20,312,15
-    PUSHBUTTON      "D…FINIR/MODIFIER...",IDC_CHANGEPASSWORDADMIN,96,41,64,14
+    LTEXT           "En tant qu'administrateur, vous pouvez d√©finir un mot de passe pour permettre aux non-administrateurs de consulter et modifier les param√®tres.",IDC_STATIC_ADMIN,12,20,312,15
+    PUSHBUTTON      "D√âFINIR/MODIFIER...",IDC_CHANGEPASSWORDADMIN,96,41,64,14
     PUSHBUTTON      "EFFACER",IDC_ADMINCLEAR,171,41,50,14
 END
 
@@ -715,7 +715,7 @@ FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     CONTROL         "Autoriser les connexions Loopback",IDC_ALLOWLOOPBACK,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,43,104,10
     CONTROL         "Loopback uniquement",IDC_LOOPBACKONLY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,160,43,58,10
-    CONTROL         "Autoriser le mode IPv6 (redÈmarrage requis)",IDC_IPV6,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,56,130,10
+    CONTROL         "Autoriser le mode IPv6 (red√©marrage requis)",IDC_IPV6,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,56,130,10
     GROUPBOX        "Connexion entrante",IDC_STATIC,7,7,344,195
     CONTROL         "Activer le port entrant",IDC_CONNECT_SOCK,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,16,75,11
     CONTROL         "Manuel",IDC_SPECPORT,"Button",BS_AUTORADIOBUTTON,271,30,37,10
@@ -729,40 +729,40 @@ BEGIN
     CONTROL         "Verrouiller le poste (Windows 2000)",IDC_LOCKSETTING_LOCK,
                     "Button",BS_AUTORADIOBUTTON,94,82,120,11
     CONTROL         "Fermer la session",IDC_LOCKSETTING_LOGOFF,"Button",BS_AUTORADIOBUTTON,240,82,72,11
-    CONTROL         "DÈconnecter toutes les connexions existantes",IDC_MV1,"Button",BS_AUTORADIOBUTTON | WS_GROUP,20,111,127,10
+    CONTROL         "D√©connecter toutes les connexions existantes",IDC_MV1,"Button",BS_AUTORADIOBUTTON | WS_GROUP,20,111,127,10
     CONTROL         "Conserver les connexions existantes",IDC_MV2,"Button",BS_AUTORADIOBUTTON,20,121,104,10
     CONTROL         "Refuser la nouvelle connexion",IDC_MV3,"Button",BS_AUTORADIOBUTTON,183,111,103,10
     CONTROL         "Refuser toutes les nouvelles connexions",IDC_MV4,"Button",BS_AUTORADIOBUTTON,183,121,102,10
     EDITTEXT        IDC_KINTERVAL,92,160,19,12,ES_AUTOHSCROLL
     LTEXT           "Intervalle keepalive",IDC_STATIC,15,162,75,9
-    LTEXT           "DÈlai d'inactivitÈ: (entrÈe)",IDC_STATIC,15,142,75,9
+    LTEXT           "D√©lai d'inactivit√© (entr√©e)",IDC_STATIC,15,142,75,9
     EDITTEXT        IDC_IDLETIMEINPUT,92,141,19,12,ES_AUTOHSCROLL
     LTEXT           "Envoyer keepalive toutes les x secondes",IDC_STATIC,139,162,115,8
-    LTEXT           "Instruct viewer to disconnect when idle for x sec.  0 = disabled",IDC_STATIC,139,139,122,15
+    LTEXT           "Demander au client de se d√©connecter apr√®s x sec. d'inactivit√©. 0 = d√©sactiv√©",IDC_STATIC,139,139,122,15
     EDITTEXT        IDC_MAXVIEWERS,62,187,18,12,ES_AUTOHSCROLL
-    LTEXT           "Viewers max",IDC_STATIC,15,188,46,8
+    LTEXT           "Clients max",IDC_STATIC,15,188,46,8
     CONTROL         "Refuser",IDC_MAXREFUSE,"Button",BS_AUTORADIOBUTTON,155,188,38,10
-    CONTROL         "DÈconnecter le plus ancien",IDC_MAXDISCONNECT,"Button",BS_AUTORADIOBUTTON,204,188,73,10
+    CONTROL         "D√©connecter le plus ancien",IDC_MAXDISCONNECT,"Button",BS_AUTORADIOBUTTON,204,188,73,10
     LTEXT           "Action",IDC_STATIC,98,188,43,10
-    LTEXT           "¿ la derniËre dÈconnexion viewer",IDC_STATIC,15,71,83,8
+    LTEXT           "√Ä la derni√®re d√©connexion client",IDC_STATIC,15,71,83,8
     LTEXT           "Lors de connexions multiples",IDC_STATIC,15,100,87,8
 END
 
 IDD_EDIT_IP_ACESS_CONTROL DIALOGEX 0, 0, 227, 147
 STYLE DS_SETFONT | DS_MODALFRAME | DS_3DLOOK | DS_FIXEDSYS | DS_CENTER | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
-CAPTION "UltraVNC Server - Edit IPv4 Access Rule"
+CAPTION "UltraVNC Server - Modifier une r√®gle d'acc√®s IPv4"
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     GROUPBOX        "Adresses IPv4",IDC_STATIC,0,5,223,58,WS_GROUP
-    LTEXT           "ModËle correspondant",IDC_STATIC,15,17,59,8
+    LTEXT           "Mod√®le correspondant",IDC_STATIC,15,17,59,8
     EDITTEXT        IDC_FIRST_IP,80,16,64,12,ES_AUTOHSCROLL | WS_GROUP
     GROUPBOX        "Action",IDC_STATIC,0,65,223,56
     DEFPUSHBUTTON   "OK",IDOK,110,127,50,15,WS_GROUP
-    PUSHBUTTON      "ANNULER",IDCANCEL,169,127,50,15
+    PUSHBUTTON      "Annuler",IDCANCEL,169,127,50,15
     CONTROL         "Autoriser",IDC_ALLOW,"Button",BS_AUTORADIOBUTTON | BS_MULTILINE,12,78,33,10
     CONTROL         "Refuser",IDC_DENY,"Button",BS_AUTORADIOBUTTON,12,91,37,10
-    CONTROL         "Demander ‡ l'utilisateur local",IDC_QUERY,"Button",BS_AUTORADIOBUTTON,12,104,59,10
-    LTEXT           "IPv4 address format template:\na.b.c.d or a.b.c. or a.b or a or empty\na.b.c = range from a.b.c.1 to a.b.c.254",IDC_STATIC,8,39,209,28
+    CONTROL         "Demander √† l'utilisateur local",IDC_QUERY,"Button",BS_AUTORADIOBUTTON,12,104,59,10
+    LTEXT           "Format d'adresse IPv4 :\na.b.c.d ou a.b.c. ou a.b ou a ou vide\na.b.c = plage de a.b.c.1 √† a.b.c.254",IDC_STATIC,8,39,209,28
     LTEXT           "",IDC_ERROR_TEXT,7,130,97,8
 END
 
@@ -770,26 +770,26 @@ IDD_FORM_capture DIALOGEX 0, 0, 361, 209
 STYLE DS_SETFONT | DS_FIXEDSYS | WS_CHILD
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
-    CONTROL         "Interroger plein Ècran",IDC_POLL_FULLSCREEN,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,21,112,13
-    CONTROL         "Interroger fenÍtre au premier plan",IDC_POLL_FOREGROUND,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,21,34,89,15
-    CONTROL         "Interroger fenÍtre sous le curseur",IDC_POLL_UNDER_CURSOR,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,21,50,104,12
-    CONTROL         "Interroger fenÍtres console seul.",IDC_CONSOLE_ONLY,"Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_TABSTOP,161,34,99,15
-    CONTROL         "Interroger uniquement sur ÈvÈnement",IDC_ONEVENT_ONLY,"Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_TABSTOP,161,50,78,12
-    CONTROL         "Hook systËme (vnchook.dll)",IDC_HOOK,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,84,110,10
+    CONTROL         "Interroger plein √©cran",IDC_POLL_FULLSCREEN,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,21,112,13
+    CONTROL         "Interroger la fen√™tre au premier plan",IDC_POLL_FOREGROUND,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,21,34,89,15
+    CONTROL         "Interroger la fen√™tre sous le curseur",IDC_POLL_UNDER_CURSOR,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,21,50,104,12
+    CONTROL         "Interroger les fen√™tres console uniquement",IDC_CONSOLE_ONLY,"Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_TABSTOP,161,34,99,15
+    CONTROL         "Interroger uniquement sur √©v√©nement",IDC_ONEVENT_ONLY,"Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_TABSTOP,161,50,78,12
+    CONTROL         "Hook syst√®me (vnchook.dll)",IDC_HOOK,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,84,110,10
     CONTROL         "Mirror Driver (<= Windows 7)",IDC_DRIVER,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,100,205,10
-    CONTROL         "Faible prÈcision (Vitesse turbo)",IDC_TURBOMODE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,68,112,10
-    PUSHBUTTON      "V…RIFIER PILOTE MIRROR",IDC_CHECKDRIVER,13,156,92,11
+    CONTROL         "Faible pr√©cision (mode turbo)",IDC_TURBOMODE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,68,112,10
+    PUSHBUTTON      "V√âRIFIER PILOTE MIRROR",IDC_CHECKDRIVER,13,156,92,11
     EDITTEXT        IDC_MAXCPU,54,176,40,14,ES_AUTOHSCROLL | ES_NUMBER
-    LTEXT           "Max CPU",IDC_STATIC,13,178,34,8
-    LTEXT           "AccËs ÈlevÈ requis: Service ou exÈcuter en admin",IDC_STATICELEVATED,185,154,166,19
+    LTEXT           "CPU max",IDC_STATIC,13,178,34,8
+    LTEXT           "Acc√®s √©lev√© requis : service ou ex√©cution en administrateur",IDC_STATICELEVATED,185,154,166,19
     CONTROL         "Auto",IDC_AUTOCAPT1,"Button",BS_AUTORADIOBUTTON,97,116,31,10
     CONTROL         "Pixel",IDC_AUTOCAPT2,"Button",BS_AUTORADIOBUTTON,161,116,31,10
     CONTROL         "Blit",IDC_AUTOCAPT3,"Button",BS_AUTORADIOBUTTON,225,116,25,10
-    LTEXT           "Capture hÈritÈe",IDC_STATIC,13,116,54,8
+    LTEXT           "Capture h√©rit√©e",IDC_STATIC,13,116,54,8
     CONTROL         "",IDC_SLIDERFPS,"msctls_trackbar32",TBS_AUTOTICKS | TBS_TOP | WS_TABSTOP,71,130,133,12
-    LTEXT           "Max FPS",IDC_STATICFPS5,13,133,29,8
+    LTEXT           "FPS max",IDC_STATICFPS5,13,133,29,8
     LTEXT           "60",IDC_STATICFPS,214,134,9,8
-    GROUPBOX        "Capture d'Ècran",IDC_STATIC,7,7,344,195
+    GROUPBOX        "Capture d'√©cran",IDC_STATIC,7,7,344,195
 END
 
 IDD_FORM_Rules DIALOGEX 0, 0, 361, 209
@@ -797,43 +797,43 @@ STYLE DS_SETFONT | DS_FIXEDSYS | WS_CHILD
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     CONTROL         "",IDQUERY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,12,19,8,8
-    LTEXT           "DurÈe d'affichage du message (s)",IDC_STATIC,36,48,134,8
+    LTEXT           "Dur√©e d'affichage du message (s)",IDC_STATIC,36,48,134,8
     EDITTEXT        IDQUERYTIMEOUT,12,46,19,12,ES_AUTOHSCROLL
-    LTEXT           "Action de requÍte par dÈfaut",IDC_STATIC,13,88,64,8
+    LTEXT           "Action par d√©faut de la requ√™te",IDC_STATIC,13,88,64,8
     CONTROL         "Refuser",IDC_DREFUSE,"Button",BS_AUTORADIOBUTTON | WS_GROUP,87,87,39,10
     CONTROL         "Accepter",IDC_DACCEPT,"Button",BS_AUTORADIOBUTTON,140,87,39,10
-    CONTROL         "Refuse (allow locked)",IDC_DRefuseOnly,"Button",BS_AUTORADIOBUTTON,193,87,88,10
+    CONTROL         "Refuser (autoriser si verrouill√©)",IDC_DRefuseOnly,"Button",BS_AUTORADIOBUTTON,193,87,88,10
     EDITTEXT        IDC_QUERYDISABLETIME,12,61,19,12,ES_AUTOHSCROLL
-    LTEXT           "DÈlai avant affichage du message (s)",IDC_STATIC,36,63,158,8
+    LTEXT           "D√©lai avant affichage du message (s)",IDC_STATIC,36,63,158,8
     EDITTEXT        IDC_EDITQUERYTEXT,12,30,206,12,ES_AUTOHSCROLL
-    LTEXT           "Message popup personnalisÈ",IDC_STATIC,225,32,99,8
-    CONTROL         "Show messagebox when no user is logged or screen is locked",IDC_QNOLOGON,
+    LTEXT           "Message popup personnalis√©",IDC_STATIC,225,32,99,8
+    CONTROL         "Afficher la bo√Æte de message si aucun utilisateur n'est connect√© ou si l'√©cran est verrouill√©",IDC_QNOLOGON,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,76,206,10
-    GROUPBOX        "RËgles",IDC_STATIC,7,7,344,195,WS_GROUP
+    GROUPBOX        "R√®gles",IDC_STATIC,7,7,344,195,WS_GROUP
     CONTROL         "",IDC_IP_ACCESS_CONTROL_LIST,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_ALIGNLEFT | WS_BORDER | WS_GROUP | WS_TABSTOP,12,119,244,61
     DEFPUSHBUTTON   "Ajouter...",IDC_ADD_BUTTON,274,119,57,10,WS_GROUP
     PUSHBUTTON      "Modifier...",IDC_EDIT_BUTTON,274,132,57,10
     PUSHBUTTON      "Supprimer",IDC_REMOVE_BUTTON,274,145,57,10
     PUSHBUTTON      "Monter",IDC_MOVE_UP_BUTTON,274,158,57,10
     PUSHBUTTON      "Descendre",IDC_MOVE_DOWN_BUTTON,274,171,57,10
-    LTEXT           "Check the rules above:",IDC_STATIC,16,187,52,8
+    LTEXT           "Tester les r√®gles ci-dessus :",IDC_STATIC,16,187,52,8
     EDITTEXT        IDC_IP_FOR_CHECK_EDIT,72,186,44,12,ES_AUTOHSCROLL | WS_GROUP
-    LTEXT           "[check result]",IDC_IP_CHECK_RESULT_LABEL,177,188,46,8
-    PUSHBUTTON      "VÈrifier",IDC_CHECKIP,125,186,44,12
-    LTEXT           "Popup a timed messagebox to allow the user to allow/reject an incoming connect",IDC_STATIC,24,19,264,11
-    LTEXT           "Allow locked: no messagebox when screen is locked",IDC_STATIC,87,99,180,12
+    LTEXT           "[r√©sultat du test]",IDC_IP_CHECK_RESULT_LABEL,177,188,46,8
+    PUSHBUTTON      "V√©rifier",IDC_CHECKIP,125,186,44,12
+    LTEXT           "Afficher une bo√Æte de message minut√©e pour permettre √† l'utilisateur d'accepter ou refuser une connexion entrante",IDC_STATIC,24,19,264,11
+    LTEXT           "Autoriser si verrouill√© : pas de bo√Æte de message si l'√©cran est verrouill√©",IDC_STATIC,87,99,180,12
 END
 
 IDD_FORM_Notifications DIALOGEX 0, 0, 361, 211
 STYLE DS_SETFONT | DS_FIXEDSYS | WS_CHILD
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
-    CONTROL         "Cadre indicateur autour de l'Ècran partagÈ",IDC_FRAME,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,21,167,10
-    CONTROL         "Afficher notification popup lors de connexion viewer",IDC_NOTIFOCATION,
+    CONTROL         "Cadre indicateur autour de l'√©cran partag√©",IDC_FRAME,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,21,167,10
+    CONTROL         "Afficher une notification popup lors de la connexion d'un client",IDC_NOTIFOCATION,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,32,160,10
-    CONTROL         "Toujours afficher notification, utiliser celle du client si disponible",IDC_RADIONOTIFICATIONON,
+    CONTROL         "Toujours afficher la notification, utiliser celle du client si disponible",IDC_RADIONOTIFICATIONON,
                     "Button",BS_AUTORADIOBUTTON,39,45,250,10
-    CONTROL         "Afficher uniquement si le client fournit info notification",IDC_RADIONOTIFICATIONIFPROVIDED,
+    CONTROL         "Afficher uniquement si le client fournit une info de notification",IDC_RADIONOTIFICATIONIFPROVIDED,
                     "Button",BS_AUTORADIOBUTTON,39,57,182,10
     CONTROL         "Utiliser OSD au lieu d'un popup",IDC_OSD,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,39,69,120,10
     GROUPBOX        "Notification",IDC_STATIC,7,7,344,78
@@ -844,14 +844,14 @@ STYLE DS_SETFONT | DS_FIXEDSYS | WS_CHILD
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     GROUPBOX        "Clavier && Souris",IDC_STATIC,7,7,344,49,BS_LEFT
-    CONTROL         "DÈsactiver les entrÈes Viewer",IDC_DISABLE_INPUTS,"Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_TABSTOP,14,17,92,10
-    CONTROL         "DÈsactiver les entrÈes locales",IDC_DISABLE_LOCAL_INPUTS,"Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_TABSTOP,14,29,83,10
+    CONTROL         "D√©sactiver le clavier et la souris du client",IDC_DISABLE_INPUTS,"Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_TABSTOP,14,17,92,10
+    CONTROL         "D√©sactiver le clavier et la souris du serveur",IDC_DISABLE_LOCAL_INPUTS,"Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_TABSTOP,14,29,83,10
     CONTROL         "Clavier alternatif",IDC_JAP_INPUTS,"Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_TABSTOP,14,41,89,10
     CONTROL         "Assistant clavier Windows 8",IDC_WIN8_HELPER,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,184,30,110,10
     CONTROL         "Touches internationales",IDC_UNICODE_INPUTS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,184,18,74,10
     CONTROL         "Collaboratif",IDC_COLLABO,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,184,42,58,10
     CONTROL         "Activer",IDC_FILETRANSFER,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,67,36,10
-    CONTROL         "Usurpation utilisateur (pour Service seul.)",IDC_FTUSERIMPERSONATION_CHECK,
+    CONTROL         "Emprunt d'identit√© (service uniquement)",IDC_FTUSERIMPERSONATION_CHECK,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,23,79,133,10
     GROUPBOX        "Transfert de fichiers",IDC_STATIC,7,56,344,41
 END
@@ -885,27 +885,27 @@ STYLE DS_SETFONT | DS_FIXEDSYS | WS_CHILD
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     GROUPBOX        "Divers",IDC_STATIC,7,7,344,197,BS_LEFT
-    CONTROL         "Supprimer le fond d'Ècran lors de la connexion",IDC_REMOVE_WALLPAPER,
+    CONTROL         "Supprimer le fond d'√©cran lors de la connexion",IDC_REMOVE_WALLPAPER,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,17,134,10
-    CONTROL         "Activer Ècran noir sur demande viewer",IDC_BLANK,
+    CONTROL         "Activer l'√©cran noir sur demande du client",IDC_BLANK,
                     "Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_TABSTOP,13,29,144,10
-    CONTROL         "DÈsactiver entrÈes seul. sur demande Ècran noir",IDC_BLANK2,
+    CONTROL         "D√©sactiver le clavier et la souris uniquement sur demande d'√©cran noir",IDC_BLANK2,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,23,41,142,10
-    CONTROL         "DÈsactiver icÙne barre des t‚ches",IDC_DISABLETRAY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,65,67,10
-    CONTROL         "DÈsactiver options clients dans menu icÙne",IDC_ALLOWEDITCLIENTS,
+    CONTROL         "D√©sactiver l'ic√¥ne de la barre des t√¢ches",IDC_DISABLETRAY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,65,67,10
+    CONTROL         "D√©sactiver les options clients dans le menu ic√¥ne",IDC_ALLOWEDITCLIENTS,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,101,141,10
-    CONTROL         "Interdire ‡ l'utilisateur de fermer UltraVNC Server",IDC_ALLOWSHUTDOWN,
+    CONTROL         "Interdire √† l'utilisateur de fermer UltraVNC Server",IDC_ALLOWSHUTDOWN,
                     "Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_TABSTOP,13,77,194,10
-    LTEXT           "…chelle d'Ècran par dÈfaut",IDC_STATIC,14,116,100,8
+    LTEXT           "√âchelle d'√©cran par d√©faut",IDC_STATIC,14,116,100,8
     EDITTEXT        IDC_SCALE,118,114,12,12,ES_AUTOHSCROLL
-    CONTROL         "RDPmode",IDC_RDPMODE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,53,47,10
-    CONTROL         "EmpÍcher Èconomiseur d'Ècran",IDC_NOSCREENSAVER,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,89,84,10
-    LTEXT           "…cran par dÈfaut",IDC_STATIC,14,129,47,8
+    CONTROL         "Mode RDP",IDC_RDPMODE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,53,47,10
+    CONTROL         "Emp√™cher l'√©conomiseur d'√©cran",IDC_NOSCREENSAVER,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,89,84,10
+    LTEXT           "√âcran par d√©faut",IDC_STATIC,14,129,47,8
     CONTROL         "Principal",IDC_PRIM,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,74,128,40,10
     CONTROL         "Secondaire",IDC_SEC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,127,128,50,10
     LTEXT           "Langue",IDC_LANGUAGE_LABEL,14,145,40,8
     COMBOBOX        IDC_LANGUAGE_COMBO,74,143,100,100,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "(redÈmarrage requis)",IDC_STATIC,180,145,80,8
+    LTEXT           "(red√©marrage requis)",IDC_STATIC,180,145,80,8
 END
 
 IDD_FORM_Service DIALOGEX 0, 0, 362, 209
@@ -913,9 +913,9 @@ STYLE DS_SETFONT | DS_FIXEDSYS | WS_CHILD | WS_SYSMENU
 FONT 11, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     PUSHBUTTON      "Installer le service",IDC_INSTALL_SERVICE,17,7,84,14
-    PUSHBUTTON      "DÈsinstaller le service",IDC_UNINSTALL_SERVICE,17,28,84,14
-    PUSHBUTTON      "DÈmarrer le service",IDC_START_SERVICE,17,49,84,14
-    PUSHBUTTON      "ArrÍter le service",IDC_STOP_SERVICE,17,70,84,14
+    PUSHBUTTON      "D√©sinstaller le service",IDC_UNINSTALL_SERVICE,17,28,84,14
+    PUSHBUTTON      "D√©marrer le service",IDC_START_SERVICE,17,49,84,14
+    PUSHBUTTON      "Arr√™ter le service",IDC_STOP_SERVICE,17,70,84,14
     LTEXT           "Static",IDC_SERVICE_STATUS,17,100,217,31
 END
 
@@ -1160,4 +1160,4 @@ END
 //
 #include "version.rc2"
 /////////////////////////////////////////////////////////////////////////////
-#endif    // not APSTUDIO_INVOKED 
+#endif    // not APSTUDIO_INVOKED


### PR DESCRIPTION
The French translation has been fully revised to improve naturalness, consistency, and correctness.

Key changes include:
- Terminology unified across Viewer and Server (e.g. "Affichage seul" for View only, "Mode partagé" for Share server, "Clavier et souris" for Input)
- Tab labels clarified and standardized (e.g. "Encodage", "Clavier et souris", "Écoute", "Sécurité", "Configuration")
- Missing or incorrect accents fixed throughout
- French typography applied consistently (spaces before ? ! : »)
- Several strings that were left in English have been translated
- Awkward or overly literal phrasing reworded for a more natural reading