### PR TITLE
Stack Buffer Off-by-One Write via recvfrom

### DIFF
--- a/winvnc/winvnc/UdpEchoServer.cpp
+++ b/winvnc/winvnc/UdpEchoServer.cpp
@@ -50,7 +50,7 @@ void UdpEchoServer(int port)
         char buffer[1024];
         sockaddr_in clientAddr;
         int clientAddrSize = sizeof(clientAddr);
-        int bytesReceived = recvfrom(serverSocket, buffer, sizeof(buffer), 0, reinterpret_cast<sockaddr*>(&clientAddr), &clientAddrSize);
+        int bytesReceived = recvfrom(serverSocket, buffer, sizeof(buffer) -1, 0, reinterpret_cast<sockaddr*>(&clientAddr), &clientAddrSize);
         if (bytesReceived == SOCKET_ERROR) {
             continue; // Continue to next iteration
         }


### PR DESCRIPTION
When `recvfrom` returns exactly 1024 bytes (the full buffer capacity), `bytesReceived == 1024` and the write targets `buffer[1024]` — one byte past the valid index range `[0..1023]`. This corrupts adjacent stack data. The subsequent `strcmp` at line 67 reads from this potentially corrupted buffer.